### PR TITLE
First production experience

### DIFF
--- a/app/Exceptions/EmailComplianceException.php
+++ b/app/Exceptions/EmailComplianceException.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: cyrillbolliger
+ * Date: 27.10.18
+ * Time: 16:55
+ */
+
+namespace App\Exceptions;
+
+
+class EmailComplianceException extends \Exception {
+
+	/**
+	 * Render the exception into an HTTP response.
+	 *
+	 * @param \Illuminate\Http\Request
+	 *
+	 * @return \Illuminate\Http\Response
+	 */
+	public function render( $request ) {
+		abort( 500, "Invalid payload: " . $this->getMessage() );
+	}
+}

--- a/app/Exceptions/MemberDeleteException.php
+++ b/app/Exceptions/MemberDeleteException.php
@@ -3,7 +3,7 @@
 namespace App\Exceptions;
 
 
-class EmailComplianceException extends \Exception {
+class MemberDeleteException extends \Exception {
 
 	/**
 	 * Render the exception into an HTTP response.

--- a/app/Http/MailChimpClient.php
+++ b/app/Http/MailChimpClient.php
@@ -2,6 +2,7 @@
 
 namespace App\Http;
 
+use App\Exceptions\EmailComplianceException;
 use App\Exceptions\InvalidEmailException;
 use App\Exceptions\MailchimpClientException;
 use DrewM\MailChimp\MailChimp;
@@ -174,6 +175,7 @@ class MailChimpClient {
 	 * @throws \InvalidArgumentException
 	 * @throws InvalidEmailException
 	 * @throws MailchimpClientException
+	 * @throws EmailComplianceException
 	 */
 	public function putSubscriber( array $mcData, string $email = null ) {
 		if ( empty( $mcData['email_address'] ) ) {
@@ -196,6 +198,11 @@ class MailChimpClient {
 		if ( isset( $put['status'] ) && is_numeric( $put['status'] ) && $put['status'] !== 200 ) {
 			if ( isset( $put['errors'] ) && 0 === strpos( $put['errors'][0]['message'], 'Invalid email address' ) ) {
 				throw new InvalidEmailException( $put['errors'][0]['message'] );
+			}
+		}
+		if ( isset( $put['status'] ) && is_numeric( $put['status'] ) && $put['status'] !== 200 ) {
+			if ( isset( $put['errors'] ) && strpos( $put['errors'][0]['message'], 'compliance state' ) ) {
+				throw new EmailComplianceException( $put['errors'][0]['message'] );
 			}
 		}
 		$this->validateResponseContent( 'PUT subscriber', $put );

--- a/app/Http/MailChimpClient.php
+++ b/app/Http/MailChimpClient.php
@@ -201,8 +201,8 @@ class MailChimpClient {
 			}
 		}
 		if ( isset( $put['status'] ) && is_numeric( $put['status'] ) && $put['status'] !== 200 ) {
-			if ( isset( $put['errors'] ) && strpos( $put['errors'][0]['message'], 'compliance state' ) ) {
-				throw new EmailComplianceException( $put['errors'][0]['message'] );
+			if ( isset( $put['detail'] ) && strpos( $put['detail'], 'compliance state' ) ) {
+				throw new EmailComplianceException( $put['detail'] );
 			}
 		}
 		$this->validateResponseContent( 'PUT subscriber', $put );

--- a/app/Synchronizer/MailchimpToCrmSynchronizer.php
+++ b/app/Synchronizer/MailchimpToCrmSynchronizer.php
@@ -113,13 +113,18 @@ class MailchimpToCrmSynchronizer {
 			case self::MC_CLEANED_EMAIL:
 				// set email1 to invalid
 				// add note 'email set to invalid because it bounced in mailchimp'
+				if ( 'hard' !== $mcData['data']['reason'] ) {
+					Log::debug( 'MC_CLEANED_EMAIL: Bounce not hard. No action taken.' );
+
+					return;
+				}
 				$mcData                  = $this->mcClient->getSubscriber( $email );
 				$crmId                   = $mcData['merge_fields'][ $this->config->getMailchimpKeyOfCrmId() ];
 				$get                     = $this->crmClient->get( 'member/' . $crmId );
-				$crmData                 = json_decode( (string) $get->getBody(), true );
+				$crmRespData             = json_decode( (string) $get->getBody(), true );
 				$crmData['emailStatus']  = 'invalid';
-				$crmData['notesCountry'] .= sprintf( "\n%s: Mailchimp reported the email as invalid. Email status changed.", date( 'Y-m-d H:i' ) );
-				Log::debug( 'MC_CLEANED_EMAIL: Mark email invalid in crm (crm id: $crmId).' );
+				$crmData['notesCountry'] = $crmRespData['notesCountry'] . sprintf( "\n%s: Mailchimp reported the email as invalid. Email status changed.", date( 'Y-m-d H:i' ) );
+				Log::debug( "MC_CLEANED_EMAIL: Mark email invalid in crm (crm id: $crmId)." );
 				break;
 
 			case self::MC_PROFILE_UPDATE:
@@ -128,7 +133,7 @@ class MailchimpToCrmSynchronizer {
 				$mcData  = $this->mcClient->getSubscriber( $email );
 				$crmId   = $mcData['merge_fields'][ $this->config->getMailchimpKeyOfCrmId() ];
 				$crmData = $mapper->mailchimpToCrm( $mcData );
-				Log::debug( 'MC_PROFILE_UPDATE: Update subscriptions in crm (crm id: $crmId).' );
+				Log::debug( "MC_PROFILE_UPDATE: Update subscriptions in crm (crm id: $crmId)." );
 				break;
 
 			case self::MC_EMAIL_UPDATE:
@@ -136,7 +141,7 @@ class MailchimpToCrmSynchronizer {
 				$mcData  = $this->mcClient->getSubscriber( $email );
 				$crmId   = $mcData['merge_fields'][ $this->config->getMailchimpKeyOfCrmId() ];
 				$crmData = $this->updateEmail( $mcData );
-				Log::debug( 'MC_EMAIL_UPDATE: Update email in crm (crm id: $crmId).' );
+				Log::debug( "MC_EMAIL_UPDATE: Update email in crm (crm id: $crmId)." );
 				break;
 
 			default:

--- a/app/Synchronizer/MailchimpToCrmSynchronizer.php
+++ b/app/Synchronizer/MailchimpToCrmSynchronizer.php
@@ -161,7 +161,7 @@ class MailchimpToCrmSynchronizer {
 		$this->crmClient->put( 'member/' . $crmId, $putData );
 
 		Log::debug( sprintf(
-			"Sync successful (record id: %d)",
+			"Sync successful (mailchimp record id: %d)",
 			$mailchimpId
 		) );
 	}

--- a/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
+++ b/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
@@ -194,9 +194,29 @@ class MailchimpToCrmSynchronizerTest extends TestCase {
 	}
 
 	public function testSyncSingle__bounced() {
-		// config
-		$email  = str_random() . '@mymail.com';
-		$crmId  = 123456;
+		$email = str_random() . '@mymail.com';
+		$crmId = random_int( 10 ** 6, 10 ** 7 );
+
+		// precondition
+		$subscriber = [
+			'email_address' => $email,
+			'merge_fields'  => [
+				'FNAME'     => 'First Name',
+				'LNAME'     => 'Last Name',
+				'GENDER'    => 'n',
+				'WEBLINGID' => (string) $crmId,
+			],
+			'interests'     => [
+				'55f795def4' => true,
+				'1851be732e' => false,
+				'294df36247' => true,
+				'633e3c8dd7' => false,
+			],
+			'tags'          => [],
+		];
+
+		$this->mcClientTesting->putSubscriber( $subscriber );
+
 		$member = $this->getMember( $crmId, $email );
 
 		// precondition
@@ -210,13 +230,7 @@ class MailchimpToCrmSynchronizerTest extends TestCase {
 			'type' => 'cleaned',
 			'data' => [
 				'email'  => $email,
-				'merges' => [
-					'EMAIL'     => $email,
-					'FNAME'     => 'First Name',
-					'LANME'     => 'Last Name',
-					'GENDER'    => 'n',
-					'WEBLINGID' => (string) $crmId,
-				],
+				'reason' => 'hard',
 			],
 		];
 
@@ -230,6 +244,9 @@ class MailchimpToCrmSynchronizerTest extends TestCase {
 		$this->assertEquals( 'invalid', $data['emailStatus']['value'] );
 		$this->assertStringContainsString( 'Mailchimp reported the email as invalid. Email status changed.', $data['notesCountry']['value'] );
 		$this->assertStringContainsString( $member['notesCountry'], $data['notesCountry']['value'] );
+
+		// cleanup
+		$this->mcClientTesting->deleteSubscriber( $email );
 	}
 
 	public function testSyncSingle__updated() {


### PR DESCRIPTION
Kleine Verbesserungen aus den ersten Erfahrungen im produktiven Betrieb:
* Mailchimp -> CRM: Nur bei hard bounced Kontakten die Emailadresse als ungültig markieren
* CRM -> Mailchimp: Failed Synchronisationsversuche nur wiederholen, wenn es sich nicht um eine Emailadresse handelt, die von Mailchimp gesperrt wurde (aus Compliance Gründen oder weil sie nicht gelöscht werden soll (z.B. weil kürzlich in Mailchimp unsubscribed))