### PR TITLE
Concurrency handling

### DIFF
--- a/app/Console/Commands/Sync.php
+++ b/app/Console/Commands/Sync.php
@@ -20,7 +20,8 @@ class Sync extends Command {
                             {direction : Possible values are "' . self::DIRECTION_CRM . '" and "' . self::DIRECTION_MAILCHIMP . '".}
                             {config : The name of the config file to use.}
                             {--limit=100 : How may records should be syncronized at a time.}
-                            {--offset=0 : How many records should be skipped. Usually used in combination with --limit.}';
+                            {--offset=0 : How many records should be skipped. Usually used in combination with --limit.}
+                            {--all : Ignore revision and sync all records, not just changes.}';
 
 	/**
 	 * The console command description.
@@ -81,6 +82,7 @@ class Sync extends Command {
 	private function syncToMailchimp() {
 		$limit  = $this->option( 'limit' );
 		$offset = $this->option( 'offset' );
+		$all    = $this->option( 'all' );
 
 		if ( ! is_numeric( $limit ) || (int) $limit <= 0 ) {
 			$this->error( 'The limit option must pass an integer > 0.' );
@@ -99,7 +101,7 @@ class Sync extends Command {
 			$this->info( 'Syncing... please be patient!' );
 
 			try {
-				$sync->syncAllChanges( (int) $limit, (int) $offset ); // this is the relevant line! the rest is error handling...
+				$sync->syncAllChanges( (int) $limit, (int) $offset, (bool) $all ); // this is the relevant line! the rest is error handling...
 			} catch ( ParseCrmDataException $e ) {
 				$this->error( 'ParseCrmDataException: ' . $e->getMessage() );
 				$this->error( $e->getFile() . ' on line ' . $e->getLine() . "\n" . $e->getTraceAsString(), 'v' );

--- a/app/Synchronizer/CrmToMailchimpSynchronizer.php
+++ b/app/Synchronizer/CrmToMailchimpSynchronizer.php
@@ -124,11 +124,13 @@ class CrmToMailchimpSynchronizer {
 		}
 
 		if ( 0 === $offset ) {
-			Log::debug( sprintf(
-				"Starting to sync all changes from crm into mailchimp\nConfig: %s\nId of last successfully synced revision: %d",
-				$this->configName,
-				$revId
-			) );
+			Log::debug( "Starting to sync all changes from crm into mailchimp\nConfig: {$this->configName}" );
+
+			if ( - 1 === $revId ) {
+				Log::debug( "Syncing all records regardless of changes." );
+			} else {
+				Log::debug( "Id of last successfully synced revision: $revId" );
+			}
 
 			// get latest revision id and store it in the local database
 			$this->openNewRevision();

--- a/app/Synchronizer/CrmToMailchimpSynchronizer.php
+++ b/app/Synchronizer/CrmToMailchimpSynchronizer.php
@@ -101,13 +101,14 @@ class CrmToMailchimpSynchronizer {
 	 *
 	 * @param int $limit number of records to sync at a time
 	 * @param int $offset number of records to skip
+	 * @param bool $all sync all records, not just changes
 	 *
 	 * @throws \App\Exceptions\ConfigException
 	 * @throws \App\Exceptions\ParseCrmDataException
 	 * @throws RequestException
 	 * @throws \Exception
 	 */
-	public function syncAllChanges( int $limit = 100, int $offset = 0 ) {
+	public function syncAllChanges( int $limit = 100, int $offset = 0, bool $all = false ) {
 		if ( ! $this->lock() ) {
 			Log::info( "There is already a synchronization for {$this->configName} running. Start of new sync job canceled." );
 
@@ -116,6 +117,11 @@ class CrmToMailchimpSynchronizer {
 
 		// get revision id of last successful sync (or -1 if first run)
 		$revId = $this->getLatestSuccessfullSyncRevisionId();
+
+		// sync all records instead of changes if all flag is set
+		if ( $all ) {
+			$revId = - 1;
+		}
 
 		if ( 0 === $offset ) {
 			Log::debug( sprintf(

--- a/tests/Unit/Synchronizer/CrmToMailchimpSynchronizerTest.php
+++ b/tests/Unit/Synchronizer/CrmToMailchimpSynchronizerTest.php
@@ -62,10 +62,15 @@ class CrmToMailchimpSynchronizerTest extends TestCase {
 		$filter->setAccessible( true );
 		$filter->setValue( $this->sync, new Filter( $config->getFieldMaps(), $config->getSyncAll() ) );
 
-		// add filter
+		// add mapper
 		$mapper = new \ReflectionProperty( $this->sync, 'mapper' );
 		$mapper->setAccessible( true );
 		$mapper->setValue( $this->sync, new Mapper( $config->getFieldMaps() ) );
+
+		// add lock path
+		$lockPath = new \ReflectionProperty( $this->sync, 'lockPath' );
+		$lockPath->setAccessible( true );
+		$lockPath->setValue( $this->sync, storage_path() . 'locks' );
 
 		// replace the mailchimp client with one with secure but real credentials
 		$mailchimpClient = new \ReflectionProperty( $this->sync, 'mailchimpClient' );

--- a/tests/Unit/Synchronizer/CrmToMailchimpSynchronizerTest.php
+++ b/tests/Unit/Synchronizer/CrmToMailchimpSynchronizerTest.php
@@ -68,9 +68,14 @@ class CrmToMailchimpSynchronizerTest extends TestCase {
 		$mapper->setValue( $this->sync, new Mapper( $config->getFieldMaps() ) );
 
 		// add lock path
-		$lockPath = new \ReflectionProperty( $this->sync, 'lockPath' );
-		$lockPath->setAccessible( true );
-		$lockPath->setValue( $this->sync, storage_path() . 'locks' );
+		$lockRoot = new \ReflectionProperty( $this->sync, 'lockRoot' );
+		$lockRoot->setAccessible( true );
+		$lockRoot->setValue( $this->sync, storage_path() . '/locks' );
+
+		// add lock path
+		$lockFile = new \ReflectionProperty( $this->sync, 'lockFile' );
+		$lockFile->setAccessible( true );
+		$lockFile->setValue( $this->sync, "{$lockRoot->getValue($this->sync)}/{$configName->getValue($this->sync)}.lock" );
 
 		// replace the mailchimp client with one with secure but real credentials
 		$mailchimpClient = new \ReflectionProperty( $this->sync, 'mailchimpClient' );


### PR DESCRIPTION
* Verbieted gleichzeitiges Synchronisieren einer einzelnen Instanz (Konfiguration) (closes #7)
* Fügt eine Option hinzu um die Synchronisation aller Datensätze zu erzwingen (statt nur den geänderten)