### PR TITLE
usability

### DIFF
--- a/app/Console/Commands/Sync.php
+++ b/app/Console/Commands/Sync.php
@@ -22,7 +22,8 @@ class Sync extends Command
                             {config : The name of the config file to use.}
                             {--limit=100 : How may records should be syncronized at a time.}
                             {--offset=0 : How many records should be skipped. Usually used in combination with --limit.}
-                            {--all : Ignore revision and sync all records, not just changes.}';
+                            {--all : Ignore revision and sync all records, not just changes.}
+                            {--force : Ignore locks of previously started (running or dead) sync processes.}';
     
     /**
      * The console command description.
@@ -88,6 +89,7 @@ class Sync extends Command
         $limit = $this->option('limit');
         $offset = $this->option('offset');
         $all = $this->option('all');
+        $force = $this->option('force');
         
         if (!is_numeric($limit) || (int)$limit <= 0) {
             $this->error('The limit option must pass an integer > 0.');
@@ -103,6 +105,12 @@ class Sync extends Command
         
         try {
             $sync = new CrmToMailchimpSynchronizer($this->argument('config'));
+    
+            if ($force) {
+                $this->info('Force sync -> removing locks now.');
+                $sync->unlock();
+            }
+            
             $this->info('Syncing... please be patient!');
             
             try {

--- a/app/Synchronizer/MailchimpToCrmSynchronizer.php
+++ b/app/Synchronizer/MailchimpToCrmSynchronizer.php
@@ -95,11 +95,15 @@ class MailchimpToCrmSynchronizer
         
         switch ($callType) {
             case self::MC_SUBSCRIBE:
-                // send mail to dataOwner, that he should
-                // add the subscriber to webling not mailchimp
                 $mcData = $this->mcClient->getSubscriber($email);
-                $this->sendMailSubscribeOnlyInWebling($this->config->getDataOwner(), $mcData);
-                Log::debug('MC_SUBSCRIBE: Inform data owner.');
+    
+                // if there is no crm id
+                if (empty($mcData['data']['merges'][$this->config->getMailchimpKeyOfCrmId()])) {
+                    // send mail to dataOwner, that he should
+                    // add the subscriber to webling not mailchimp
+                    $this->sendMailSubscribeOnlyInWebling($this->config->getDataOwner(), $mcData);
+                    Log::debug('MC_SUBSCRIBE: Inform data owner.');
+                }
                 
                 return;
             


### PR DESCRIPTION
* Wenn sich jemand vom Newsletter abmeldet und danach via Mailchimp ein Resubscribe macht, löst dies fälschlicherweise die Meldung aus, dass die Person direkt in Mailchimp eingetragen wurde (anstatt über Webling). Dieser Fall wird hier abgefangen und gefixed.
* Wenn manuell via CLI synchronisiert wird, stirbt der Prozess auf Grund von Verbindungsfehlern alle paar tausend Adressen. Die neue '--force' Option erleichtert ein Neustart des Prozesses. Das Lockfile muss nicht mehr manuell gelöscht werden.