### PR TITLE
Feature: Map CRM Tags to Mailchimp Groups

### DIFF
--- a/app/Console/Commands/Sync.php
+++ b/app/Console/Commands/Sync.php
@@ -20,7 +20,7 @@ class Sync extends Command
     protected $signature = 'sync:all
                             {direction : Possible values are "' . self::DIRECTION_CRM . '" and "' . self::DIRECTION_MAILCHIMP . '".}
                             {config : The name of the config file to use.}
-                            {--limit=100 : How may records should be syncronized at a time.}
+                            {--limit=100 : How may records should be synchronized at a time.}
                             {--offset=0 : How many records should be skipped. Usually used in combination with --limit.}
                             {--all : Ignore revision and sync all records, not just changes.}
                             {--force : Ignore locks of previously started (running or dead) sync processes.}';
@@ -98,7 +98,7 @@ class Sync extends Command
         }
         
         if (!is_numeric($offset) || (int)$offset < 0) {
-            $this->error('The offset option musst pass an integer >= 0.');
+            $this->error('The offset option must pass an integer >= 0.');
             
             return 1;
         }
@@ -107,7 +107,7 @@ class Sync extends Command
             $sync = new CrmToMailchimpSynchronizer($this->argument('config'));
     
             if ($force) {
-                $this->info('Force sync -> removing locks now.');
+                $this->info('Force sync -> removing locks if present.');
                 $sync->unlock();
             }
             

--- a/app/Synchronizer/CrmToMailchimpSynchronizer.php
+++ b/app/Synchronizer/CrmToMailchimpSynchronizer.php
@@ -339,7 +339,10 @@ class CrmToMailchimpSynchronizer
      */
     public function unlock()
     {
-        rmdir("{$this->lockRoot}/{$this->configName}.lock");
+        $lockfile = "{$this->lockRoot}/{$this->configName}.lock";
+        if (file_exists($lockfile)) {
+            rmdir($lockfile);
+        }
     }
     
     /**

--- a/app/Synchronizer/CrmValue.php
+++ b/app/Synchronizer/CrmValue.php
@@ -10,6 +10,7 @@ class CrmValue
     public const MODE_APPEND = 'append';
     public const MODE_REPLACE_EMPTY = 'replaceEmpty';
     public const MODE_ADD_IF_NEW = 'addIfNew';
+    public const MODE_REMOVE = 'remove';
     
     private string $key;
     private array|string|int|null $value;
@@ -77,7 +78,8 @@ class CrmValue
             self::MODE_APPEND,
             self::MODE_REPLACE,
             self::MODE_ADD_IF_NEW,
-            self::MODE_REPLACE_EMPTY
+            self::MODE_REPLACE_EMPTY,
+            self::MODE_REMOVE
         ];
         if (!in_array($mode, $allowedModes)) {
             throw new \InvalidArgumentException("Invalid mode: $mode");

--- a/app/Synchronizer/CrmValue.php
+++ b/app/Synchronizer/CrmValue.php
@@ -1,0 +1,88 @@
+<?php
+
+
+namespace App\Synchronizer;
+
+
+class CrmValue
+{
+    public const MODE_REPLACE = 'replace';
+    public const MODE_APPEND = 'append';
+    public const MODE_REPLACE_EMPTY = 'replaceEmpty';
+    public const MODE_ADD_IF_NEW = 'addIfNew';
+    
+    private string $key;
+    private array|string|int|null $value;
+    private string $mode;
+    
+    /**
+     * CrmValue constructor.
+     * @param string $key
+     * @param array|int|string|null $value
+     * @param string $mode
+     */
+    public function __construct(string $key, int|array|string|null $value, string $mode)
+    {
+        $this->setKey($key);
+        $this->setValue($value);
+        $this->setMode($mode);
+    }
+    
+    /**
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+    
+    /**
+     * @param string $key
+     */
+    public function setKey(string $key): void
+    {
+        $this->key = $key;
+    }
+    
+    /**
+     * @return array|int|string|null
+     */
+    public function getValue(): array|int|string|null
+    {
+        return $this->value;
+    }
+    
+    /**
+     * @param array|int|string|null $value
+     */
+    public function setValue(array|int|string|null $value): void
+    {
+        $this->value = $value;
+    }
+    
+    /**
+     * @return string
+     */
+    public function getMode(): string
+    {
+        return $this->mode;
+    }
+    
+    /**
+     * @param string $mode
+     */
+    public function setMode(string $mode): void
+    {
+        $allowedModes = [
+            self::MODE_APPEND,
+            self::MODE_REPLACE,
+            self::MODE_ADD_IF_NEW,
+            self::MODE_REPLACE_EMPTY
+        ];
+        if (!in_array($mode, $allowedModes)) {
+            throw new \InvalidArgumentException("Invalid mode: $mode");
+        }
+        
+        $this->mode = $mode;
+    }
+}

--- a/app/Synchronizer/Mapper/FieldMapFacade.php
+++ b/app/Synchronizer/Mapper/FieldMapFacade.php
@@ -5,6 +5,7 @@ namespace App\Synchronizer\Mapper;
 
 
 use App\Exceptions\ConfigException;
+use App\Synchronizer\CrmValue;
 use App\Synchronizer\Mapper\FieldMaps\FieldMapAutotag;
 use App\Synchronizer\Mapper\FieldMaps\FieldMapEmail;
 use App\Synchronizer\Mapper\FieldMaps\FieldMapGroup;
@@ -80,11 +81,11 @@ class FieldMapFacade
     /**
      * Get field data ready to merge into request array for crm
      *
-     * @return array
+     * @return CrmValue
      */
-    public function getCrmDataArray(): array
+    public function getCrmData(): CrmValue
     {
-        return $this->field->getCrmDataArray();
+        return $this->field->getCrmData();
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMapFacade.php
+++ b/app/Synchronizer/Mapper/FieldMapFacade.php
@@ -81,9 +81,9 @@ class FieldMapFacade
     /**
      * Get field data ready to merge into request array for crm
      *
-     * @return CrmValue
+     * @return CrmValue[]
      */
-    public function getCrmData(): CrmValue
+    public function getCrmData(): array
     {
         return $this->field->getCrmData();
     }

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMap.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMap.php
@@ -7,6 +7,7 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 use App\Exceptions\ConfigException;
 use App\Exceptions\ParseCrmDataException;
 use App\Exceptions\ParseMailchimpDataException;
+use App\Synchronizer\CrmValue;
 
 abstract class FieldMap
 {
@@ -66,9 +67,9 @@ abstract class FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return array
+     * @return CrmValue
      */
-    abstract function getCrmDataArray();
+    abstract function getCrmData();
     
     /**
      * Get key value pair ready for storing in mailchimp

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapAutotag.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapAutotag.php
@@ -7,6 +7,7 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 use App\Exceptions\ConfigException;
 use App\Exceptions\ParseCrmDataException;
 use App\Exceptions\ParseMailchimpDataException;
+use App\Synchronizer\CrmValue;
 
 /**
  * Mapper for tag fields
@@ -66,11 +67,11 @@ class FieldMapAutotag extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return array
+     * @return CrmValue
      */
-    function getCrmDataArray()
+    function getCrmData()
     {
-        return []; // don't do anything, we don't allow syncing from mailchimp to crm
+        return null; // don't do anything, we don't allow syncing from mailchimp to crm
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapAutotag.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapAutotag.php
@@ -67,11 +67,11 @@ class FieldMapAutotag extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return CrmValue
+     * @return CrmValue[]
      */
-    function getCrmData()
+    function getCrmData(): array
     {
-        return null; // don't do anything, we don't allow syncing from mailchimp to crm
+        return []; // don't do anything, we don't allow syncing from mailchimp to crm
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapEmail.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapEmail.php
@@ -7,6 +7,7 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 use App\Exceptions\ConfigException;
 use App\Exceptions\ParseCrmDataException;
 use App\Exceptions\ParseMailchimpDataException;
+use App\Synchronizer\CrmValue;
 
 /**
  * Mapper for the email field
@@ -71,11 +72,11 @@ class FieldMapEmail extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return array
+     * @return CrmValue
      */
-    function getCrmDataArray()
+    function getCrmData()
     {
-        return [$this->crmKey => $this->value];
+        return new CrmValue($this->crmKey, $this->value, CrmValue::MODE_REPLACE);
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapEmail.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapEmail.php
@@ -72,11 +72,11 @@ class FieldMapEmail extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return CrmValue
+     * @return CrmValue[]
      */
-    function getCrmData()
+    function getCrmData(): array
     {
-        return new CrmValue($this->crmKey, $this->value, CrmValue::MODE_REPLACE);
+        return [new CrmValue($this->crmKey, $this->value, CrmValue::MODE_REPLACE)];
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapGroup.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapGroup.php
@@ -95,9 +95,9 @@ class FieldMapGroup extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return CrmValue
+     * @return CrmValue[]
      */
-    function getCrmData(): CrmValue
+    function getCrmData(): array
     {
         return $this->condition->getCrmValue($this->crmKey);
     }

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapGroup.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapGroup.php
@@ -7,6 +7,9 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 use App\Exceptions\ConfigException;
 use App\Exceptions\ParseCrmDataException;
 use App\Exceptions\ParseMailchimpDataException;
+use App\Synchronizer\CrmValue;
+use App\Synchronizer\Mapper\FieldMaps\GroupConditions\GroupConditionFactory;
+use App\Synchronizer\Mapper\FieldMaps\GroupConditions\GroupConditionInterface;
 
 /**
  * Mapper for the group fields
@@ -19,17 +22,20 @@ class FieldMapGroup extends FieldMap
 {
     public const MAILCHIMP_PARENT_KEY = 'interests';
     
-    private $mailchimpCategoryId;
-    private $trueCondition;
-    private $falseCondition;
+    private string $mailchimpCategoryId;
     
-    private $mailchimpValue;
-    private $crmValue;
+    private GroupConditionInterface $condition;
     
     /**
      * FieldMapMerge constructor.
      *
-     * @param array $config {crmKey: string, mailchimpCategoryId: string, trueCondition: string, falseCondition: string, sync: {'both', 'toMailchimp'}}
+     * @param array $config {
+     *  crmKey: string,
+     *  mailchimpCategoryId: string,
+     *  (trueCondition|trueContainsString): string,
+     *  (falseCondition|trueContainsString): string,
+     *  sync: {'both', 'toMailchimp'}
+     * }
      *
      * @throws ConfigException
      */
@@ -41,16 +47,8 @@ class FieldMapGroup extends FieldMap
             throw new ConfigException('Field: Missing mailchimpCategoryId definition');
         }
         $this->mailchimpCategoryId = $config['mailchimpCategoryId'];
-        
-        if (empty($config['trueCondition'])) {
-            throw new ConfigException("Field: Missing 'trueCondition' definition");
-        }
-        $this->trueCondition = $config['trueCondition'];
-        
-        if (empty($config['falseCondition'])) {
-            throw new ConfigException("Field: Missing 'falseCondition' definition");
-        }
-        $this->falseCondition = $config['falseCondition'];
+    
+        $this->condition = GroupConditionFactory::makeFrom($config);
     }
     
     /**
@@ -74,9 +72,8 @@ class FieldMapGroup extends FieldMap
         }
         
         $inGroup = $data[self::MAILCHIMP_PARENT_KEY][$this->mailchimpCategoryId];
-        
-        $this->mailchimpValue = $inGroup;
-        $this->crmValue = $inGroup ? $this->trueCondition : $this->falseCondition;
+    
+        $this->condition->setFromBool($inGroup);
     }
     
     /**
@@ -91,19 +88,18 @@ class FieldMapGroup extends FieldMap
         if (!array_key_exists($this->crmKey, $data)) {
             throw new ParseCrmDataException(sprintf("Missing key '%s'", $this->crmKey));
         }
-        
-        $this->mailchimpValue = $data[$this->crmKey] === $this->trueCondition;
-        $this->crmValue = $data[$this->crmKey];
+    
+        $this->condition->setFromCrmData($data[$this->crmKey]);
     }
     
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return array
+     * @return CrmValue
      */
-    function getCrmDataArray()
+    function getCrmData(): CrmValue
     {
-        return [$this->crmKey => $this->crmValue];
+        return $this->condition->getCrmValue($this->crmKey);
     }
     
     /**
@@ -113,7 +109,7 @@ class FieldMapGroup extends FieldMap
      */
     function getMailchimpDataArray()
     {
-        return [$this->mailchimpCategoryId => $this->mailchimpValue];
+        return [$this->mailchimpCategoryId => $this->condition->getMailchimpValue()];
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapMerge.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapMerge.php
@@ -7,6 +7,7 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 use App\Exceptions\ConfigException;
 use App\Exceptions\ParseCrmDataException;
 use App\Exceptions\ParseMailchimpDataException;
+use App\Synchronizer\CrmValue;
 
 /**
  * Mapper for merge fields
@@ -90,11 +91,11 @@ class FieldMapMerge extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return array
+     * @return CrmValue
      */
-    function getCrmDataArray()
+    function getCrmData()
     {
-        return [$this->crmKey => $this->value];
+        return new CrmValue($this->crmKey, $this->value, CrmValue::MODE_REPLACE);
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapMerge.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapMerge.php
@@ -91,11 +91,11 @@ class FieldMapMerge extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return CrmValue
+     * @return CrmValue[]
      */
-    function getCrmData()
+    function getCrmData(): array
     {
-        return new CrmValue($this->crmKey, $this->value, CrmValue::MODE_REPLACE);
+        return [new CrmValue($this->crmKey, $this->value, CrmValue::MODE_REPLACE)];
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapTag.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapTag.php
@@ -7,6 +7,7 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 use App\Exceptions\ConfigException;
 use App\Exceptions\ParseCrmDataException;
 use App\Exceptions\ParseMailchimpDataException;
+use App\Synchronizer\CrmValue;
 
 /**
  * Mapper for tag fields
@@ -78,11 +79,11 @@ class FieldMapTag extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return array
+     * @return CrmValue
      */
-    function getCrmDataArray()
+    function getCrmData()
     {
-        return []; // don't do anything, we don't allow syncing from mailchimp to crm
+        return null; // don't do anything, we don't allow syncing from mailchimp to crm
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/FieldMapTag.php
+++ b/app/Synchronizer/Mapper/FieldMaps/FieldMapTag.php
@@ -79,11 +79,11 @@ class FieldMapTag extends FieldMap
     /**
      * Get key value pair ready for storing in the crm
      *
-     * @return CrmValue
+     * @return CrmValue[]
      */
-    function getCrmData()
+    function getCrmData(): array
     {
-        return null; // don't do anything, we don't allow syncing from mailchimp to crm
+        return []; // don't do anything, we don't allow syncing from mailchimp to crm
     }
     
     /**

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionFactory.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+
+namespace App\Synchronizer\Mapper\FieldMaps\GroupConditions;
+
+
+use App\Exceptions\ConfigException;
+
+class GroupConditionFactory
+{
+    /**
+     * GroupCondition constructor.
+     *
+     * @param array $config {
+     *  (trueCondition|trueContainsString): string,
+     *  (falseCondition|trueContainsString): string,
+     * }
+     *
+     * @throws ConfigException
+     */
+    public static function makeFrom(array $config): GroupConditionInterface
+    {
+        // 'condition' or 'containsString' must be present
+        if (empty($config['trueCondition']) && empty($config['trueContainsString'])) {
+            throw new ConfigException("Field: Missing condition definition. Either 'trueCondition' or 'trueContainsString' must be present.");
+        }
+        if (empty($config['falseCondition']) && empty($config['falseContainsString'])) {
+            throw new ConfigException("Field: Missing condition definition. Either 'falseCondition' or 'falseContainsString' must be present.");
+        }
+        
+        // both, 'condition' and 'containsString' at the same time are not allowed
+        if (!empty($config['trueCondition']) && !empty($config['trueContainsString'])) {
+            throw new ConfigException("Field: 'trueCondition' and 'trueContainsString' are mutually exclusive. Make sure there is only one of them.");
+        }
+        if (!empty($config['falseCondition']) && !empty($config['falseContainsString'])) {
+            throw new ConfigException("Field: 'falseCondition' and 'falseContainsString' are mutually exclusive. Make sure there is only one of them.");
+        }
+        
+        // 'condition' and 'containsString' must be the same for 'true' and 'false'
+        if (!empty($config['trueCondition']) && !empty($config['falseContainsString'])) {
+            throw new ConfigException("Field: 'trueCondition' and 'falseContainsString' can not be combined. If you use 'trueCondition' you must use 'falseCondition'.");
+        }
+        if (!empty($config['trueContainsString']) && !empty($config['falseCondition'])) {
+            throw new ConfigException("Field: 'trueContainsString' and 'falseCondition' can not be combined. If you use 'trueContainsString' you must use 'falseContainsString'.");
+        }
+        
+        // set 'condition'
+        if (!empty($config['trueCondition']) && !empty($config['falseCondition'])) {
+            return new GroupStringBoolCondition($config['trueCondition'], $config['falseCondition']);
+        }
+        
+        // set 'containsString'
+        if (!empty($config['trueContainsString']) && !empty($config['falseContainsString'])) {
+            return new GroupStringContainsCondition($config['trueContainsString'], $config['falseContainsString']);
+        }
+        
+        throw new ConfigException('Field: Invalid condition definition. Either "trueCondition" and "falseCondition" or "trueContainsString" and "falseContainsString" must be present.');
+    }
+}

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionInterface.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionInterface.php
@@ -10,7 +10,7 @@ interface GroupConditionInterface
 {
     public function __construct(string $trueCondition, string $falseCondition);
     
-    public function setFromCrmData(string $crmStringData);
+    public function setFromCrmData(?string $crmStringData);
     
     public function setFromBool(bool $bool);
     

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionInterface.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionInterface.php
@@ -14,7 +14,11 @@ interface GroupConditionInterface
     
     public function setFromBool(bool $bool);
     
-    public function getCrmValue(string $crmFieldKey): CrmValue;
+    /**
+     * @param string $crmFieldKey
+     * @return CrmValue[]
+     */
+    public function getCrmValue(string $crmFieldKey): array;
     
     public function getMailchimpValue(): bool;
 }

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionInterface.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupConditionInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace App\Synchronizer\Mapper\FieldMaps\GroupConditions;
+
+
+use App\Synchronizer\CrmValue;
+
+interface GroupConditionInterface
+{
+    public function __construct(string $trueCondition, string $falseCondition);
+    
+    public function setFromCrmData(string $crmStringData);
+    
+    public function setFromBool(bool $bool);
+    
+    public function getCrmValue(string $crmFieldKey): CrmValue;
+    
+    public function getMailchimpValue(): bool;
+}

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringBoolCondition.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringBoolCondition.php
@@ -18,7 +18,7 @@ class GroupStringBoolCondition implements GroupConditionInterface
         $this->falseCondition = $falseCondition;
     }
     
-    public function setFromCrmData(string $crmStringData)
+    public function setFromCrmData(?string $crmStringData)
     {
         $this->value = $crmStringData === $this->trueCondition;
     }

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringBoolCondition.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringBoolCondition.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace App\Synchronizer\Mapper\FieldMaps\GroupConditions;
+
+
+use App\Synchronizer\CrmValue;
+
+class GroupStringBoolCondition implements GroupConditionInterface
+{
+    private string $trueCondition;
+    private string $falseCondition;
+    private bool $value;
+    
+    public function __construct(string $trueCondition, string $falseCondition)
+    {
+        $this->trueCondition = $trueCondition;
+        $this->falseCondition = $falseCondition;
+    }
+    
+    public function setFromCrmData(string $crmStringData)
+    {
+        $this->value = $crmStringData === $this->trueCondition;
+    }
+    
+    public function setFromBool(bool $bool)
+    {
+        $this->value = $bool;
+    }
+    
+    public function getCrmValue(string $crmFieldKey): CrmValue
+    {
+        $value = $this->value ? $this->trueCondition : $this->falseCondition;
+        return new CrmValue($crmFieldKey, $value, CrmValue::MODE_REPLACE);
+    }
+    
+    public function getMailchimpValue(): bool
+    {
+        return $this->value;
+    }
+}

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringBoolCondition.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringBoolCondition.php
@@ -28,10 +28,10 @@ class GroupStringBoolCondition implements GroupConditionInterface
         $this->value = $bool;
     }
     
-    public function getCrmValue(string $crmFieldKey): CrmValue
+    public function getCrmValue(string $crmFieldKey): array
     {
         $value = $this->value ? $this->trueCondition : $this->falseCondition;
-        return new CrmValue($crmFieldKey, $value, CrmValue::MODE_REPLACE);
+        return [new CrmValue($crmFieldKey, $value, CrmValue::MODE_REPLACE)];
     }
     
     public function getMailchimpValue(): bool

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringContainsCondition.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringContainsCondition.php
@@ -18,15 +18,15 @@ class GroupStringContainsCondition implements GroupConditionInterface
         $this->falseCondition = $falseCondition;
     }
     
-    public function setFromCrmData(string $crmStringData)
+    public function setFromCrmData(?string $crmStringData)
     {
         // the false condition must always have precedence over the true condition
-        if (str_contains($crmStringData, $this->falseCondition)) {
+        if (str_contains((string)$crmStringData, $this->falseCondition)) {
             $this->value = false;
             return;
         }
-        
-        $this->value = str_contains($crmStringData, $this->trueCondition);
+    
+        $this->value = str_contains((string)$crmStringData, $this->trueCondition);
     }
     
     public function setFromBool(bool $bool)

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringContainsCondition.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringContainsCondition.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace App\Synchronizer\Mapper\FieldMaps\GroupConditions;
+
+
+use App\Synchronizer\CrmValue;
+
+class GroupStringContainsCondition implements GroupConditionInterface
+{
+    private string $trueCondition;
+    private string $falseCondition;
+    private bool $value;
+    
+    public function __construct(string $trueCondition, string $falseCondition)
+    {
+        $this->trueCondition = $trueCondition;
+        $this->falseCondition = $falseCondition;
+    }
+    
+    public function setFromCrmData(string $crmStringData)
+    {
+        // the false condition must always have precedence over the true condition
+        if (str_contains($crmStringData, $this->falseCondition)) {
+            $this->value = false;
+            return;
+        }
+        
+        $this->value = str_contains($crmStringData, $this->trueCondition);
+    }
+    
+    public function setFromBool(bool $bool)
+    {
+        $this->value = $bool;
+    }
+    
+    public function getCrmValue(string $crmFieldKey): CrmValue
+    {
+        $value = $this->value ? $this->trueCondition : $this->falseCondition;
+        return new CrmValue($crmFieldKey, $value, CrmValue::MODE_APPEND);
+    }
+    
+    public function getMailchimpValue(): bool
+    {
+        return $this->value;
+    }
+}

--- a/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringContainsCondition.php
+++ b/app/Synchronizer/Mapper/FieldMaps/GroupConditions/GroupStringContainsCondition.php
@@ -34,10 +34,14 @@ class GroupStringContainsCondition implements GroupConditionInterface
         $this->value = $bool;
     }
     
-    public function getCrmValue(string $crmFieldKey): CrmValue
+    public function getCrmValue(string $crmFieldKey): array
     {
-        $value = $this->value ? $this->trueCondition : $this->falseCondition;
-        return new CrmValue($crmFieldKey, $value, CrmValue::MODE_APPEND);
+        $append = $this->value ? $this->trueCondition : $this->falseCondition;
+        $remove = !$this->value ? $this->trueCondition : $this->falseCondition;
+        return [
+            new CrmValue($crmFieldKey, $append, CrmValue::MODE_APPEND),
+            new CrmValue($crmFieldKey, $remove, CrmValue::MODE_REMOVE)
+        ];
     }
     
     public function getMailchimpValue(): bool

--- a/app/Synchronizer/Mapper/Mapper.php
+++ b/app/Synchronizer/Mapper/Mapper.php
@@ -37,7 +37,12 @@ class Mapper
             if ($map->canSyncToCrm()) {
                 $map->addMailchimpData($mailchimpData);
                 $crmData = $map->getCrmData();
-                $data[$crmData->getKey()] = $crmData;
+                foreach ($crmData as $action) {
+                    $data[$action->getKey()][] = [
+                        'value' => $action->getValue(),
+                        'mode' => $action->getMode()
+                    ];
+                }
             }
         }
         

--- a/app/Synchronizer/Mapper/Mapper.php
+++ b/app/Synchronizer/Mapper/Mapper.php
@@ -36,7 +36,8 @@ class Mapper
         foreach ($this->fieldMaps as $map) {
             if ($map->canSyncToCrm()) {
                 $map->addMailchimpData($mailchimpData);
-                $data = array_merge($data, $map->getCrmDataArray());
+                $crmData = $map->getCrmData();
+                $data[$crmData->getKey()] = $crmData;
             }
         }
         

--- a/composer.lock
+++ b/composer.lock
@@ -772,19 +772,19 @@
             "time": "2021-04-26T09:17:50+00:00"
         },
         {
-            "name": "laravel/framework",
-            "version": "v8.41.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laravel/framework.git",
-                "reference": "05417155d886df8710e55c84e12622b52d83c47c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/05417155d886df8710e55c84e12622b52d83c47c",
-                "reference": "05417155d886df8710e55c84e12622b52d83c47c",
-                "shasum": ""
-            },
+          "name": "laravel/framework",
+          "version": "v8.49.0",
+          "source": {
+            "type": "git",
+            "url": "https://github.com/laravel/framework.git",
+            "reference": "855a919d08b45f93cb3cf709736528c3d1531884"
+          },
+          "dist": {
+            "type": "zip",
+            "url": "https://api.github.com/repos/laravel/framework/zipball/855a919d08b45f93cb3cf709736528c3d1531884",
+            "reference": "855a919d08b45f93cb3cf709736528c3d1531884",
+            "shasum": ""
+          },
             "require": {
                 "doctrine/inflector": "^1.4|^2.0",
                 "dragonmantank/cron-expression": "^3.0.2",
@@ -855,17 +855,17 @@
                 "illuminate/view": "self.version"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^3.155",
-                "doctrine/dbal": "^2.6|^3.0",
-                "filp/whoops": "^2.8",
-                "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
-                "league/flysystem-cached-adapter": "^1.0",
-                "mockery/mockery": "^1.4.2",
-                "orchestra/testbench-core": "^6.8",
-                "pda/pheanstalk": "^4.0",
-                "phpunit/phpunit": "^8.5.8|^9.3.3",
-                "predis/predis": "^1.1.1",
-                "symfony/cache": "^5.1.4"
+              "aws/aws-sdk-php": "^3.155",
+              "doctrine/dbal": "^2.6|^3.0",
+              "filp/whoops": "^2.8",
+              "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
+              "league/flysystem-cached-adapter": "^1.0",
+              "mockery/mockery": "^1.4.2",
+              "orchestra/testbench-core": "^6.23",
+              "pda/pheanstalk": "^4.0",
+              "phpunit/phpunit": "^8.5.8|^9.3.3",
+              "predis/predis": "^1.1.2",
+              "symfony/cache": "^5.1.4"
             },
             "suggest": {
                 "aws/aws-sdk-php": "Required to use the SQS queue driver, DynamoDb failed job storage and SES mail driver (^3.155).",
@@ -937,7 +937,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2021-05-11T14:00:02+00:00"
+          "time": "2021-06-29T13:50:21+00:00"
         },
         {
             "name": "laravel/slack-notification-channel",
@@ -1068,20 +1068,20 @@
             },
             "time": "2021-03-02T16:53:12+00:00"
         },
-        {
-            "name": "league/commonmark",
-            "version": "1.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "2651c497f005de305c7ba3f232cbd87b8c00ee8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/2651c497f005de305c7ba3f232cbd87b8c00ee8c",
-                "reference": "2651c497f005de305c7ba3f232cbd87b8c00ee8c",
-                "shasum": ""
-            },
+      {
+        "name": "league/commonmark",
+        "version": "1.6.5",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/thephpleague/commonmark.git",
+          "reference": "44ffd8d3c4a9133e4bd0548622b09c55af39db5f"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/44ffd8d3c4a9133e4bd0548622b09c55af39db5f",
+          "reference": "44ffd8d3c4a9133e4bd0548622b09c55af39db5f",
+          "shasum": ""
+        },
             "require": {
                 "ext-mbstring": "*",
                 "php": "^7.1 || ^8.0"
@@ -1090,17 +1090,17 @@
                 "scrutinizer/ocular": "1.7.*"
             },
             "require-dev": {
-                "cebe/markdown": "~1.0",
-                "commonmark/commonmark.js": "0.29.2",
-                "erusev/parsedown": "~1.0",
-                "ext-json": "*",
-                "github/gfm": "0.29.0",
-                "michelf/php-markdown": "~1.4",
-                "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan": "^0.12",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
-                "scrutinizer/ocular": "^1.5",
-                "symfony/finder": "^4.2"
+              "cebe/markdown": "~1.0",
+              "commonmark/commonmark.js": "0.29.2",
+              "erusev/parsedown": "~1.0",
+              "ext-json": "*",
+              "github/gfm": "0.29.0",
+              "michelf/php-markdown": "~1.4",
+              "mikehaertl/php-shellcommand": "^1.4",
+              "phpstan/phpstan": "^0.12.90",
+              "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
+              "scrutinizer/ocular": "^1.5",
+              "symfony/finder": "^4.2"
             },
             "bin": [
                 "bin/commonmark"
@@ -1167,22 +1167,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-08T16:08:00+00:00"
+        "time": "2021-06-26T11:57:13+00:00"
         },
-        {
-            "name": "league/flysystem",
-            "version": "1.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "9be3b16c877d477357c015cec057548cf9b2a14a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/9be3b16c877d477357c015cec057548cf9b2a14a",
-                "reference": "9be3b16c877d477357c015cec057548cf9b2a14a",
-                "shasum": ""
-            },
+      {
+        "name": "league/flysystem",
+        "version": "1.1.4",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/thephpleague/flysystem.git",
+          "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
+          "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
+          "shasum": ""
+        },
             "require": {
                 "ext-fileinfo": "*",
                 "league/mime-type-detection": "^1.3",
@@ -1196,7 +1196,6 @@
                 "phpunit/phpunit": "^8.5.8"
             },
             "suggest": {
-                "ext-fileinfo": "Required for MimeType",
                 "ext-ftp": "Allows you to use FTP server storage",
                 "ext-openssl": "Allows you to use FTPS server storage",
                 "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
@@ -1254,7 +1253,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.x"
+              "source": "https://github.com/thephpleague/flysystem/tree/1.1.4"
             },
             "funding": [
                 {
@@ -1262,7 +1261,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2020-08-23T07:39:11+00:00"
+        "time": "2021-06-23T21:56:05+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -1416,20 +1415,20 @@
             ],
             "time": "2020-12-14T13:15:25+00:00"
         },
-        {
-            "name": "nesbot/carbon",
-            "version": "2.47.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "606262fd8888b75317ba9461825a24fc34001e1e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/606262fd8888b75317ba9461825a24fc34001e1e",
-                "reference": "606262fd8888b75317ba9461825a24fc34001e1e",
-                "shasum": ""
-            },
+      {
+        "name": "nesbot/carbon",
+        "version": "2.50.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/briannesbitt/Carbon.git",
+          "reference": "f47f17d17602b2243414a44ad53d9f8b9ada5fdb"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/f47f17d17602b2243414a44ad53d9f8b9ada5fdb",
+          "reference": "f47f17d17602b2243414a44ad53d9f8b9ada5fdb",
+          "shasum": ""
+        },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
@@ -1477,27 +1476,27 @@
             ],
             "authors": [
                 {
-                    "name": "Brian Nesbitt",
-                    "email": "brian@nesbot.com",
-                    "homepage": "http://nesbot.com"
+                  "name": "Brian Nesbitt",
+                  "email": "brian@nesbot.com",
+                  "homepage": "https://markido.com"
                 },
-                {
-                    "name": "kylekatarnls",
-                    "homepage": "http://github.com/kylekatarnls"
-                }
+              {
+                "name": "kylekatarnls",
+                "homepage": "https://github.com/kylekatarnls"
+              }
             ],
-            "description": "An API extension for DateTime that supports 281 different languages.",
-            "homepage": "http://carbon.nesbot.com",
-            "keywords": [
-                "date",
-                "datetime",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/briannesbitt/Carbon/issues",
-                "source": "https://github.com/briannesbitt/Carbon"
-            },
-            "funding": [
+        "description": "An API extension for DateTime that supports 281 different languages.",
+        "homepage": "https://carbon.nesbot.com",
+        "keywords": [
+          "date",
+          "datetime",
+          "time"
+        ],
+        "support": {
+          "issues": "https://github.com/briannesbitt/Carbon/issues",
+          "source": "https://github.com/briannesbitt/Carbon"
+        },
+        "funding": [
                 {
                     "url": "https://opencollective.com/Carbon",
                     "type": "open_collective"
@@ -1507,7 +1506,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-13T21:54:02+00:00"
+        "time": "2021-06-28T22:38:45+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2366,27 +2365,28 @@
             ],
             "time": "2021-03-09T12:30:35+00:00"
         },
-        {
-            "name": "symfony/console",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/90374b8ed059325b49a29b55b3f8bb4062c87629",
-                "reference": "90374b8ed059325b49a29b55b3f8bb4062c87629",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/console",
+        "version": "v5.3.2",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/console.git",
+          "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+          "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+          "shasum": ""
+        },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php73": "^1.8",
-                "symfony/polyfill-php80": "^1.15",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+              "php": ">=7.2.5",
+              "symfony/deprecation-contracts": "^2.1",
+              "symfony/polyfill-mbstring": "~1.0",
+              "symfony/polyfill-php73": "^1.8",
+              "symfony/polyfill-php80": "^1.15",
+              "symfony/service-contracts": "^1.1|^2",
+              "symfony/string": "^5.1"
             },
             "conflict": {
                 "symfony/dependency-injection": "<4.4",
@@ -2445,7 +2445,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.2.7"
+              "source": "https://github.com/symfony/console/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -2461,22 +2461,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-19T14:07:32+00:00"
+        "time": "2021-06-12T09:42:48+00:00"
         },
-        {
-            "name": "symfony/css-selector",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/css-selector.git",
-                "reference": "59a684f5ac454f066ecbe6daecce6719aed283fb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/59a684f5ac454f066ecbe6daecce6719aed283fb",
-                "reference": "59a684f5ac454f066ecbe6daecce6719aed283fb",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/css-selector",
+        "version": "v5.3.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/css-selector.git",
+          "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/css-selector/zipball/fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
+          "reference": "fcd0b29a7a0b1bb5bfbedc6231583d77fea04814",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5"
             },
@@ -2510,7 +2510,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v5.3.0-BETA1"
+              "source": "https://github.com/symfony/css-selector/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -2526,7 +2526,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-07T16:07:52+00:00"
+        "time": "2021-05-26T17:40:38+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -2595,20 +2595,20 @@
             ],
             "time": "2021-03-23T23:28:01+00:00"
         },
-        {
-            "name": "symfony/error-handler",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/error-handler.git",
-                "reference": "ea3ddbf67615e883ca7c33a4de61213789846782"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/ea3ddbf67615e883ca7c33a4de61213789846782",
-                "reference": "ea3ddbf67615e883ca7c33a4de61213789846782",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/error-handler",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/error-handler.git",
+          "reference": "43323e79c80719e8a4674e33484bca98270d223f"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/error-handler/zipball/43323e79c80719e8a4674e33484bca98270d223f",
+          "reference": "43323e79c80719e8a4674e33484bca98270d223f",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "psr/log": "^1.0",
@@ -2646,7 +2646,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v5.2.7"
+              "source": "https://github.com/symfony/error-handler/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -2662,22 +2662,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-07T15:57:33+00:00"
+        "time": "2021-06-24T08:13:00+00:00"
         },
-        {
-            "name": "symfony/event-dispatcher",
-            "version": "v5.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d08d6ec121a425897951900ab692b612a61d6240"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d08d6ec121a425897951900ab692b612a61d6240",
-                "reference": "d08d6ec121a425897951900ab692b612a61d6240",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/event-dispatcher",
+        "version": "v5.3.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/event-dispatcher.git",
+          "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67a5f354afa8e2f231081b3fa11a5912f933c3ce",
+          "reference": "67a5f354afa8e2f231081b3fa11a5912f933c3ce",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
@@ -2731,7 +2731,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.4"
+              "source": "https://github.com/symfony/event-dispatcher/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -2747,7 +2747,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-18T17:12:37+00:00"
+        "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2828,20 +2828,20 @@
             ],
             "time": "2021-03-23T23:28:01+00:00"
         },
-        {
-            "name": "symfony/finder",
-            "version": "v5.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "0d639a0943822626290d169965804f79400e6a04"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/0d639a0943822626290d169965804f79400e6a04",
-                "reference": "0d639a0943822626290d169965804f79400e6a04",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/finder",
+        "version": "v5.3.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/finder.git",
+          "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/finder/zipball/0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+          "reference": "0ae3f047bed4edff6fd35b26a9a6bfdc92c953c6",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5"
             },
@@ -2871,7 +2871,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.2.4"
+              "source": "https://github.com/symfony/finder/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -2887,7 +2887,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-15T18:55:04+00:00"
+        "time": "2021-05-26T12:52:38+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -2967,20 +2967,20 @@
             ],
             "time": "2021-04-11T23:07:08+00:00"
         },
-        {
-            "name": "symfony/http-foundation",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "a416487a73bb9c9d120e9ba3a60547f4a3fb7a1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/a416487a73bb9c9d120e9ba3a60547f4a3fb7a1f",
-                "reference": "a416487a73bb9c9d120e9ba3a60547f4a3fb7a1f",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/http-foundation",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/http-foundation.git",
+          "reference": "0e45ab1574caa0460d9190871a8ce47539e40ccf"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/http-foundation/zipball/0e45ab1574caa0460d9190871a8ce47539e40ccf",
+          "reference": "0e45ab1574caa0460d9190871a8ce47539e40ccf",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
@@ -3022,7 +3022,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v5.2.7"
+              "source": "https://github.com/symfony/http-foundation/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -3038,69 +3038,69 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-01T13:46:24+00:00"
+        "time": "2021-06-27T09:19:40+00:00"
         },
-        {
-            "name": "symfony/http-kernel",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "1e9f6879f070f718e0055fbac232a56f67b8b6bd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1e9f6879f070f718e0055fbac232a56f67b8b6bd",
-                "reference": "1e9f6879f070f718e0055fbac232a56f67b8b6bd",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/http-kernel",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/http-kernel.git",
+          "reference": "90ad9f4b21ddcb8ebe9faadfcca54929ad23f9f8"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/http-kernel/zipball/90ad9f4b21ddcb8ebe9faadfcca54929ad23f9f8",
+          "reference": "90ad9f4b21ddcb8ebe9faadfcca54929ad23f9f8",
+          "shasum": ""
+        },
             "require": {
-                "php": ">=7.2.5",
-                "psr/log": "~1.0",
-                "symfony/deprecation-contracts": "^2.1",
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^5.0",
-                "symfony/http-client-contracts": "^1.1|^2",
-                "symfony/http-foundation": "^4.4|^5.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-php73": "^1.9",
-                "symfony/polyfill-php80": "^1.15"
+              "php": ">=7.2.5",
+              "psr/log": "~1.0",
+              "symfony/deprecation-contracts": "^2.1",
+              "symfony/error-handler": "^4.4|^5.0",
+              "symfony/event-dispatcher": "^5.0",
+              "symfony/http-client-contracts": "^1.1|^2",
+              "symfony/http-foundation": "^5.3",
+              "symfony/polyfill-ctype": "^1.8",
+              "symfony/polyfill-php73": "^1.9",
+              "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
-                "symfony/browser-kit": "<4.4",
-                "symfony/cache": "<5.0",
-                "symfony/config": "<5.0",
-                "symfony/console": "<4.4",
-                "symfony/dependency-injection": "<5.1.8",
-                "symfony/doctrine-bridge": "<5.0",
-                "symfony/form": "<5.0",
-                "symfony/http-client": "<5.0",
-                "symfony/mailer": "<5.0",
-                "symfony/messenger": "<5.0",
-                "symfony/translation": "<5.0",
-                "symfony/twig-bridge": "<5.0",
-                "symfony/validator": "<5.0",
-                "twig/twig": "<2.13"
+              "symfony/browser-kit": "<4.4",
+              "symfony/cache": "<5.0",
+              "symfony/config": "<5.0",
+              "symfony/console": "<4.4",
+              "symfony/dependency-injection": "<5.3",
+              "symfony/doctrine-bridge": "<5.0",
+              "symfony/form": "<5.0",
+              "symfony/http-client": "<5.0",
+              "symfony/mailer": "<5.0",
+              "symfony/messenger": "<5.0",
+              "symfony/translation": "<5.0",
+              "symfony/twig-bridge": "<5.0",
+              "symfony/validator": "<5.0",
+              "twig/twig": "<2.13"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
-                "psr/cache": "^1.0|^2.0|^3.0",
-                "symfony/browser-kit": "^4.4|^5.0",
-                "symfony/config": "^5.0",
-                "symfony/console": "^4.4|^5.0",
-                "symfony/css-selector": "^4.4|^5.0",
-                "symfony/dependency-injection": "^5.1.8",
-                "symfony/dom-crawler": "^4.4|^5.0",
-                "symfony/expression-language": "^4.4|^5.0",
-                "symfony/finder": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/routing": "^4.4|^5.0",
-                "symfony/stopwatch": "^4.4|^5.0",
-                "symfony/translation": "^4.4|^5.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "twig/twig": "^2.13|^3.0.4"
+              "psr/cache": "^1.0|^2.0|^3.0",
+              "symfony/browser-kit": "^4.4|^5.0",
+              "symfony/config": "^5.0",
+              "symfony/console": "^4.4|^5.0",
+              "symfony/css-selector": "^4.4|^5.0",
+              "symfony/dependency-injection": "^5.3",
+              "symfony/dom-crawler": "^4.4|^5.0",
+              "symfony/expression-language": "^4.4|^5.0",
+              "symfony/finder": "^4.4|^5.0",
+              "symfony/process": "^4.4|^5.0",
+              "symfony/routing": "^4.4|^5.0",
+              "symfony/stopwatch": "^4.4|^5.0",
+              "symfony/translation": "^4.4|^5.0",
+              "symfony/translation-contracts": "^1.1|^2",
+              "twig/twig": "^2.13|^3.0.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -3134,7 +3134,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v5.2.7"
+              "source": "https://github.com/symfony/http-kernel/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -3150,22 +3150,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-01T14:53:15+00:00"
+        "time": "2021-06-30T08:27:49+00:00"
         },
-        {
-            "name": "symfony/mime",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/mime.git",
-                "reference": "7af452bf51c46f18da00feb32e1ad36db9426515"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/7af452bf51c46f18da00feb32e1ad36db9426515",
-                "reference": "7af452bf51c46f18da00feb32e1ad36db9426515",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/mime",
+        "version": "v5.3.2",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/mime.git",
+          "reference": "47dd7912152b82d0d4c8d9040dbc93d6232d472a"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/mime/zipball/47dd7912152b82d0d4c8d9040dbc93d6232d472a",
+          "reference": "47dd7912152b82d0d4c8d9040dbc93d6232d472a",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
@@ -3217,7 +3217,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v5.2.7"
+              "source": "https://github.com/symfony/mime/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -3233,22 +3233,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-29T20:47:09+00:00"
+        "time": "2021-06-09T10:58:01+00:00"
         },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-ctype",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-ctype.git",
+          "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+          "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
@@ -3258,7 +3258,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3296,7 +3296,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3312,22 +3312,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+        "time": "2021-02-19T12:13:01+00:00"
         },
-        {
-            "name": "symfony/polyfill-iconv",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/06fb361659649bcfd6a208a0f1fcaf4e827ad342",
-                "reference": "06fb361659649bcfd6a208a0f1fcaf4e827ad342",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-iconv",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-iconv.git",
+          "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/63b5bb7db83e5673936d6e3b8b3e022ff6474933",
+          "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
@@ -3337,7 +3337,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3376,7 +3376,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-iconv/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3392,22 +3392,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+        "time": "2021-05-27T09:27:20+00:00"
         },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-intl-grapheme",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+          "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+          "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
@@ -3417,7 +3417,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3457,7 +3457,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3473,22 +3473,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+        "time": "2021-05-27T09:17:38+00:00"
         },
-        {
-            "name": "symfony/polyfill-intl-idn",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/2d63434d922daf7da8dd863e7907e67ee3031483",
-                "reference": "2d63434d922daf7da8dd863e7907e67ee3031483",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-intl-idn",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-intl-idn.git",
+          "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+          "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1",
                 "symfony/polyfill-intl-normalizer": "^1.10",
@@ -3500,7 +3500,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3544,7 +3544,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3560,22 +3560,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+        "time": "2021-05-27T09:27:20+00:00"
         },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-intl-normalizer",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+          "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+          "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
@@ -3585,7 +3585,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3628,7 +3628,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3644,22 +3644,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+        "time": "2021-02-19T12:13:01+00:00"
         },
-        {
-            "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
-                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-mbstring",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-mbstring.git",
+          "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+          "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
@@ -3669,7 +3669,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3708,7 +3708,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3724,29 +3724,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-22T09:19:47+00:00"
+        "time": "2021-05-27T09:27:20+00:00"
         },
-        {
-            "name": "symfony/polyfill-php72",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php72.git",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "reference": "cc6e6f9b39fe8075b3dabfbaf5b5f645ae1340c9",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-php72",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-php72.git",
+          "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+          "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3784,7 +3784,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-php72/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3800,29 +3800,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+        "time": "2021-05-27T09:17:38+00:00"
         },
-        {
-            "name": "symfony/polyfill-php73",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "reference": "a678b42e92f86eca04b7fa4c0f6f19d097fb69e2",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-php73",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-php73.git",
+          "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+          "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3863,7 +3863,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3879,29 +3879,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+        "time": "2021-02-19T12:13:01+00:00"
         },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.22.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "reference": "dc3063ba22c2a1fd2f45ed856374d79114998f91",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/polyfill-php80",
+        "version": "v1.23.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/polyfill-php80.git",
+          "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+          "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                  "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3946,7 +3946,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
+              "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -3962,22 +3962,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+        "time": "2021-02-19T12:13:01+00:00"
         },
-        {
-            "name": "symfony/process",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
-                "reference": "98cb8eeb72e55d4196dd1e36f1f16e7b3a9a088e",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/process",
+        "version": "v5.3.2",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/process.git",
+          "reference": "714b47f9196de61a196d86c4bad5f09201b307df"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/process/zipball/714b47f9196de61a196d86c4bad5f09201b307df",
+          "reference": "714b47f9196de61a196d86c4bad5f09201b307df",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-php80": "^1.15"
@@ -4008,7 +4008,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.3.0-BETA1"
+              "source": "https://github.com/symfony/process/tree/v5.3.2"
             },
             "funding": [
                 {
@@ -4024,40 +4024,41 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-08T10:27:02+00:00"
+        "time": "2021-06-12T10:15:01+00:00"
         },
-        {
-            "name": "symfony/routing",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/routing.git",
-                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
-                "reference": "3f0cab2e95b5e92226f34c2c1aa969d3fc41f48c",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/routing",
+        "version": "v5.3.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/routing.git",
+          "reference": "368e81376a8e049c37cb80ae87dbfbf411279199"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/routing/zipball/368e81376a8e049c37cb80ae87dbfbf411279199",
+          "reference": "368e81376a8e049c37cb80ae87dbfbf411279199",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
-                "symfony/config": "<5.0",
-                "symfony/dependency-injection": "<4.4",
-                "symfony/yaml": "<4.4"
+              "doctrine/annotations": "<1.12",
+              "symfony/config": "<5.3",
+              "symfony/dependency-injection": "<4.4",
+              "symfony/yaml": "<4.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.10.4",
-                "psr/log": "~1.0",
-                "symfony/config": "^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/expression-language": "^4.4|^5.0",
-                "symfony/http-foundation": "^4.4|^5.0",
-                "symfony/yaml": "^4.4|^5.0"
+              "doctrine/annotations": "^1.12",
+              "psr/log": "~1.0",
+              "symfony/config": "^5.3",
+              "symfony/dependency-injection": "^4.4|^5.0",
+              "symfony/expression-language": "^4.4|^5.0",
+              "symfony/http-foundation": "^4.4|^5.0",
+              "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/config": "For using the all-in-one router or any loader",
@@ -4097,7 +4098,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.2.7"
+              "source": "https://github.com/symfony/routing/tree/v5.3.0"
             },
             "funding": [
                 {
@@ -4113,7 +4114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-11T22:55:21+00:00"
+        "time": "2021-05-26T17:43:10+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4194,20 +4195,20 @@
             ],
             "time": "2021-04-01T10:43:52+00:00"
         },
-        {
-            "name": "symfony/string",
-            "version": "v5.2.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
-                "reference": "ad0bd91bce2054103f5eaa18ebeba8d3bc2a0572",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/string",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/string.git",
+          "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+          "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8",
@@ -4259,7 +4260,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.2.6"
+              "source": "https://github.com/symfony/string/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -4275,27 +4276,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-03-17T17:12:15+00:00"
+        "time": "2021-06-27T11:44:38+00:00"
         },
-        {
-            "name": "symfony/translation",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "e37ece5242564bceea54d709eafc948377ec9749"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/e37ece5242564bceea54d709eafc948377ec9749",
-                "reference": "e37ece5242564bceea54d709eafc948377ec9749",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/translation",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/translation.git",
+          "reference": "380b8c9e944d0e364b25f28e8e555241eb49c01c"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/translation/zipball/380b8c9e944d0e364b25f28e8e555241eb49c01c",
+          "reference": "380b8c9e944d0e364b25f28e8e555241eb49c01c",
+          "shasum": ""
+        },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.15",
-                "symfony/translation-contracts": "^2.3"
+              "php": ">=7.2.5",
+              "symfony/deprecation-contracts": "^2.1",
+              "symfony/polyfill-mbstring": "~1.0",
+              "symfony/polyfill-php80": "^1.15",
+              "symfony/translation-contracts": "^2.3"
             },
             "conflict": {
                 "symfony/config": "<4.4",
@@ -4308,15 +4310,16 @@
                 "symfony/translation-implementation": "2.3"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/console": "^4.4|^5.0",
-                "symfony/dependency-injection": "^5.0",
-                "symfony/finder": "^4.4|^5.0",
-                "symfony/http-kernel": "^5.0",
-                "symfony/intl": "^4.4|^5.0",
-                "symfony/service-contracts": "^1.1.2|^2",
-                "symfony/yaml": "^4.4|^5.0"
+              "psr/log": "~1.0",
+              "symfony/config": "^4.4|^5.0",
+              "symfony/console": "^4.4|^5.0",
+              "symfony/dependency-injection": "^5.0",
+              "symfony/finder": "^4.4|^5.0",
+              "symfony/http-kernel": "^5.0",
+              "symfony/intl": "^4.4|^5.0",
+              "symfony/polyfill-intl-icu": "^1.21",
+              "symfony/service-contracts": "^1.1.2|^2",
+              "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "psr/log-implementation": "To use logging capability in translator",
@@ -4352,7 +4355,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v5.2.7"
+              "source": "https://github.com/symfony/translation/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -4368,7 +4371,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-01T08:15:21+00:00"
+        "time": "2021-06-27T12:22:47+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -4448,20 +4451,20 @@
             ],
             "time": "2021-03-23T23:28:01+00:00"
         },
-        {
-            "name": "symfony/var-dumper",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "27cb9f7cfa3853c736425c7233a8f68814b19636"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/27cb9f7cfa3853c736425c7233a8f68814b19636",
-                "reference": "27cb9f7cfa3853c736425c7233a8f68814b19636",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/var-dumper",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/var-dumper.git",
+          "reference": "46aa709affb9ad3355bd7a810f9662d71025c384"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/var-dumper/zipball/46aa709affb9ad3355bd7a810f9662d71025c384",
+          "reference": "46aa709affb9ad3355bd7a810f9662d71025c384",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/polyfill-mbstring": "~1.0",
@@ -4518,7 +4521,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v5.2.7"
+              "source": "https://github.com/symfony/var-dumper/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -4534,22 +4537,22 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-19T14:07:32+00:00"
+        "time": "2021-06-24T08:13:00+00:00"
         },
-        {
-            "name": "symfony/yaml",
-            "version": "v5.2.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
-                "reference": "76546cbeddd0a9540b4e4e57eddeec3e9bb444a5",
-                "shasum": ""
-            },
+      {
+        "name": "symfony/yaml",
+        "version": "v5.3.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/symfony/yaml.git",
+          "reference": "485c83a2fb5893e2ff21bf4bfc7fdf48b4967229"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/symfony/yaml/zipball/485c83a2fb5893e2ff21bf4bfc7fdf48b4967229",
+          "reference": "485c83a2fb5893e2ff21bf4bfc7fdf48b4967229",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.2.5",
                 "symfony/deprecation-contracts": "^2.1",
@@ -4593,7 +4596,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v5.2.7"
+              "source": "https://github.com/symfony/yaml/tree/v5.3.3"
             },
             "funding": [
                 {
@@ -4609,7 +4612,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-29T20:47:09+00:00"
+        "time": "2021-06-24T08:13:00+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -5000,20 +5003,20 @@
             },
             "time": "2020-10-16T08:27:54+00:00"
         },
-        {
-            "name": "filp/whoops",
-            "version": "2.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/filp/whoops.git",
-                "reference": "c13c0be93cff50f88bbd70827d993026821914dd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/c13c0be93cff50f88bbd70827d993026821914dd",
-                "reference": "c13c0be93cff50f88bbd70827d993026821914dd",
-                "shasum": ""
-            },
+      {
+        "name": "filp/whoops",
+        "version": "2.13.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/filp/whoops.git",
+          "reference": "2edbc73a4687d9085c8f20f398eebade844e8424"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/filp/whoops/zipball/2edbc73a4687d9085c8f20f398eebade844e8424",
+          "reference": "2edbc73a4687d9085c8f20f398eebade844e8424",
+          "shasum": ""
+        },
             "require": {
                 "php": "^5.5.9 || ^7.0 || ^8.0",
                 "psr/log": "^1.0.1"
@@ -5061,7 +5064,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.12.1"
+              "source": "https://github.com/filp/whoops/tree/2.13.0"
             },
             "funding": [
                 {
@@ -5069,7 +5072,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-04-25T12:00:00+00:00"
+        "time": "2021-06-04T12:00:00+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -5252,20 +5255,20 @@
             ],
             "time": "2020-11-13T09:40:50+00:00"
         },
-        {
-            "name": "nunomaduro/collision",
-            "version": "v5.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "41b7e9999133d5082700d31a1d0977161df8322a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/41b7e9999133d5082700d31a1d0977161df8322a",
-                "reference": "41b7e9999133d5082700d31a1d0977161df8322a",
-                "shasum": ""
-            },
+      {
+        "name": "nunomaduro/collision",
+        "version": "v5.5.0",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/nunomaduro/collision.git",
+          "reference": "b5cb36122f1c142c3c3ee20a0ae778439ef0244b"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/nunomaduro/collision/zipball/b5cb36122f1c142c3c3ee20a0ae778439ef0244b",
+          "reference": "b5cb36122f1c142c3c3ee20a0ae778439ef0244b",
+          "shasum": ""
+        },
             "require": {
                 "facade/ignition-contracts": "^1.0",
                 "filp/whoops": "^2.7.2",
@@ -5338,7 +5341,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-04-09T13:38:32+00:00"
+        "time": "2021-06-22T20:47:22+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5994,20 +5997,20 @@
             ],
             "time": "2020-10-26T13:16:10+00:00"
         },
-        {
-            "name": "phpunit/phpunit",
-            "version": "9.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c73c6737305e779771147af66c96ca6a7ed8a741",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741",
-                "shasum": ""
-            },
+      {
+        "name": "phpunit/phpunit",
+        "version": "9.5.6",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/sebastianbergmann/phpunit.git",
+          "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+          "reference": "fb9b8333f14e3dce976a60ef6a7e05c7c7ed8bfb",
+          "shasum": ""
+        },
             "require": {
                 "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
@@ -6025,18 +6028,18 @@
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
-                "sebastian/version": "^3.0.2"
+              "phpunit/php-timer": "^5.0.2",
+              "sebastian/cli-parser": "^1.0.1",
+              "sebastian/code-unit": "^1.0.6",
+              "sebastian/comparator": "^4.0.5",
+              "sebastian/diff": "^4.0.3",
+              "sebastian/environment": "^5.1.3",
+              "sebastian/exporter": "^4.0.3",
+              "sebastian/global-state": "^5.0.1",
+              "sebastian/object-enumerator": "^4.0.3",
+              "sebastian/resource-operations": "^3.0.3",
+              "sebastian/type": "^2.3.4",
+              "sebastian/version": "^3.0.2"
             },
             "require-dev": {
                 "ext-pdo": "*",
@@ -6083,7 +6086,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.4"
+              "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.6"
             },
             "funding": [
                 {
@@ -6095,7 +6098,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-23T07:16:29+00:00"
+        "time": "2021-06-23T05:14:38+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -6601,20 +6604,20 @@
             ],
             "time": "2020-09-28T05:24:23+00:00"
         },
-        {
-            "name": "sebastian/global-state",
-            "version": "5.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
-                "shasum": ""
-            },
+      {
+        "name": "sebastian/global-state",
+        "version": "5.0.3",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/sebastianbergmann/global-state.git",
+          "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+          "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.3",
                 "sebastian/object-reflector": "^2.0",
@@ -6655,7 +6658,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+              "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
             },
             "funding": [
                 {
@@ -6663,7 +6666,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+        "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -6952,20 +6955,20 @@
             ],
             "time": "2020-09-28T06:45:17+00:00"
         },
-        {
-            "name": "sebastian/type",
-            "version": "2.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "shasum": ""
-            },
+      {
+        "name": "sebastian/type",
+        "version": "2.3.4",
+        "source": {
+          "type": "git",
+          "url": "https://github.com/sebastianbergmann/type.git",
+          "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+        },
+        "dist": {
+          "type": "zip",
+          "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+          "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+          "shasum": ""
+        },
             "require": {
                 "php": ">=7.3"
             },
@@ -6998,7 +7001,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+              "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
             },
             "funding": [
                 {
@@ -7006,7 +7009,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+        "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -7122,5 +7125,5 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+  "plugin-api-version": "2.1.0"
 }

--- a/config/example.com.yml
+++ b/config/example.com.yml
@@ -58,6 +58,12 @@ fields:
     trueCondition: yes
     falseCondition: no
     sync: both
+  - crmKey: notesCountry
+    mailchimpCategoryId: bba5d2d564
+    type: group
+    trueContainsString: PolitletterDE
+    falseContainsString: PolitletterUnsubscribed
+    sync: both
   - crmKey: memberStatusCountry
     mailchimpTagName: member
     type: tag

--- a/config/example.com.yml
+++ b/config/example.com.yml
@@ -62,7 +62,7 @@ fields:
     mailchimpCategoryId: bba5d2d564
     type: group
     trueContainsString: PolitletterDE
-    falseContainsString: PolitletterUnsubscribed
+    falseContainsString: PolitletterUnsubscribedDE
     sync: both
   - crmKey: memberStatusCountry
     mailchimpTagName: member

--- a/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
+++ b/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
@@ -310,7 +310,6 @@ class MailchimpToCrmSynchronizerTest extends TestCase
         
         // precondition
         $this->mockCrmResponse([
-            new Response(200, [], json_encode($member)),
             new Response(201)
         ]);
         
@@ -326,13 +325,14 @@ class MailchimpToCrmSynchronizerTest extends TestCase
         $this->sync->syncSingle($webhookData);
         
         /** @var Request $put */
-        $put = $this->crmRequestHistory[1]['request'];
+        $put = $this->crmRequestHistory[0]['request'];
         $data = json_decode((string)$put->getBody(), true);
         
         $this->assertEquals("member/$crmId", $put->getUri()->getPath());
         $this->assertEquals('invalid', $data['emailStatus']['value']);
+        $this->assertEquals('replace', $data['emailStatus']['mode']);
         $this->assertStringContainsString('Mailchimp reported the email as invalid. Email status changed.', $data['notesCountry']['value']);
-        $this->assertStringContainsString($member['notesCountry'], $data['notesCountry']['value']);
+        $this->assertEquals('append', $data['notesCountry']['mode']);
         
         // cleanup
         $this->mcClientTesting->deleteSubscriber($email);

--- a/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
+++ b/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
@@ -99,6 +99,7 @@ class MailchimpToCrmSynchronizerTest extends TestCase
                 '1851be732e' => false,
                 '294df36247' => true,
                 '633e3c8dd7' => false,
+                'bba5d2d564' => true,
             ],
             'tags' => [],
         ];
@@ -222,18 +223,22 @@ class MailchimpToCrmSynchronizerTest extends TestCase
                 ],
             ],
         ];
-        
+    
         $this->sync->syncSingle($webhookData);
-        
+    
         /** @var Request $put */
         $put = $this->crmRequestHistory[1]['request'];
         $data = json_decode((string)$put->getBody(), true);
-        
+    
         $this->assertEquals("member/$crmId", $put->getUri()->getPath());
-        $this->assertEquals('no', $data['newsletterCountryD']['value']);
-        $this->assertEquals('no', $data['newsletterCountryF']['value']);
-        $this->assertEquals('no', $data['pressReleaseCountryD']['value']);
-        $this->assertEquals('no', $data['pressReleaseCountryF']['value']);
+        $this->assertEquals('no', $data['newsletterCountryD'][0]['value']);
+        $this->assertEquals('no', $data['newsletterCountryF'][0]['value']);
+        $this->assertEquals('no', $data['pressReleaseCountryD'][0]['value']);
+        $this->assertEquals('no', $data['pressReleaseCountryF'][0]['value']);
+        $this->assertEquals('PolitletterUnsubscribed', $data['notesCountry'][0]['value']);
+        $this->assertEquals('append', $data['notesCountry'][0]['mode']);
+        $this->assertEquals('PolitletterDE', $data['notesCountry'][1]['value']);
+        $this->assertEquals('remove', $data['notesCountry'][1]['mode']);
     }
     
     private function mockCrmResponse(array $responses)
@@ -321,19 +326,19 @@ class MailchimpToCrmSynchronizerTest extends TestCase
                 'reason' => 'hard',
             ],
         ];
-        
+    
         $this->sync->syncSingle($webhookData);
-        
+    
         /** @var Request $put */
         $put = $this->crmRequestHistory[0]['request'];
         $data = json_decode((string)$put->getBody(), true);
-        
+    
         $this->assertEquals("member/$crmId", $put->getUri()->getPath());
-        $this->assertEquals('invalid', $data['emailStatus']['value']);
-        $this->assertEquals('replace', $data['emailStatus']['mode']);
-        $this->assertStringContainsString('Mailchimp reported the email as invalid. Email status changed.', $data['notesCountry']['value']);
-        $this->assertEquals('append', $data['notesCountry']['mode']);
-        
+        $this->assertEquals('invalid', $data['emailStatus'][0]['value']);
+        $this->assertEquals('replace', $data['emailStatus'][0]['mode']);
+        $this->assertStringContainsString('Mailchimp reported the email as invalid. Email status changed.', $data['notesCountry'][0]['value']);
+        $this->assertEquals('append', $data['notesCountry'][0]['mode']);
+    
         // cleanup
         $this->mcClientTesting->deleteSubscriber($email);
     }
@@ -365,6 +370,7 @@ class MailchimpToCrmSynchronizerTest extends TestCase
                 '1851be732e' => false,
                 '294df36247' => true,
                 '633e3c8dd7' => false,
+                'bba5d2d564' => true,
             ],
             'tags' => [],
         ];
@@ -385,19 +391,23 @@ class MailchimpToCrmSynchronizerTest extends TestCase
                 ],
             ],
         ];
-        
+    
         $this->sync->syncSingle($webhookData);
-        
+    
         /** @var Request $put */
         $put = $this->crmRequestHistory[0]['request'];
         $data = json_decode((string)$put->getBody(), true);
-        
+    
         $this->assertEquals("member/$crmId", $put->getUri()->getPath());
-        $this->assertEquals('yes', $data['newsletterCountryD']['value']);
-        $this->assertEquals('no', $data['newsletterCountryF']['value']);
-        $this->assertEquals('yes', $data['pressReleaseCountryD']['value']);
-        $this->assertEquals('no', $data['pressReleaseCountryF']['value']);
-        
+        $this->assertEquals('yes', $data['newsletterCountryD'][0]['value']);
+        $this->assertEquals('no', $data['newsletterCountryF'][0]['value']);
+        $this->assertEquals('yes', $data['pressReleaseCountryD'][0]['value']);
+        $this->assertEquals('no', $data['pressReleaseCountryF'][0]['value']);
+        $this->assertEquals('PolitletterDE', $data['notesCountry'][0]['value']);
+        $this->assertEquals('append', $data['notesCountry'][0]['mode']);
+        $this->assertEquals('PolitletterUnsubscribed', $data['notesCountry'][1]['value']);
+        $this->assertEquals('remove', $data['notesCountry'][1]['mode']);
+    
         // cleanup
         $this->mcClientTesting->deleteSubscriber($email);
     }
@@ -450,8 +460,8 @@ class MailchimpToCrmSynchronizerTest extends TestCase
         /** @var Request $put */
         $put = $this->crmRequestHistory[0]['request'];
         $data = json_decode((string)$put->getBody(), true);
-        
+    
         $this->assertEquals("member/$crmId", $put->getUri()->getPath());
-        $this->assertEquals($newEmail, $data['email1']['value']);
+        $this->assertEquals($newEmail, $data['email1'][0]['value']);
     }
 }

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapAutotagTest.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapAutotagTest.php
@@ -28,7 +28,7 @@ class FieldMapAutotagTest extends TestCase
         $map = new FieldMapAutotag($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
         
-        $this->assertEmpty($map->getCrmDataArray());
+        $this->assertEmpty($map->getCrmData());
     }
     
     private function getMailchimpData()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapEmailTest.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapEmailTest.php
@@ -36,9 +36,9 @@ class FieldMapEmailTest extends TestCase
         $map = new FieldMapEmail($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
     
-        self::assertEquals('email1', $map->getCrmData()->getKey());
-        self::assertEquals('info@example.org', $map->getCrmData()->getValue());
-        self::assertEquals('replace', $map->getCrmData()->getMode());
+        self::assertEquals('email1', $map->getCrmData()[0]->getKey());
+        self::assertEquals('info@example.org', $map->getCrmData()[0]->getValue());
+        self::assertEquals('replace', $map->getCrmData()[0]->getMode());
     }
     
     private function getMailchimpData()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapEmailTest.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapEmailTest.php
@@ -31,12 +31,14 @@ class FieldMapEmailTest extends TestCase
         ];
     }
     
-    public function testGetCrmDataArray()
+    public function testGetCrmDatay()
     {
         $map = new FieldMapEmail($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
-        
-        $this->assertEquals(['email1' => 'info@example.org'], $map->getCrmDataArray());
+    
+        self::assertEquals('email1', $map->getCrmData()->getKey());
+        self::assertEquals('info@example.org', $map->getCrmData()->getValue());
+        self::assertEquals('replace', $map->getCrmData()->getMode());
     }
     
     private function getMailchimpData()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Bool__Test.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Bool__Test.php
@@ -5,14 +5,16 @@ namespace App\Synchronizer\Mapper\FieldMaps;
 
 use Tests\TestCase;
 
-class FieldMapGroupTest extends TestCase
+class FieldMapGroup__Bool__Test extends TestCase
 {
-    public function testGetCrmDataArray__add()
+    public function testGetCrmData__add()
     {
         $map = new FieldMapGroup($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
         
-        $this->assertEquals(['newsletterCountryD' => 'yes'], $map->getCrmDataArray());
+        self::assertEquals('newsletterCountryD', $map->getCrmData()->getKey());
+        self::assertEquals('yes', $map->getCrmData()->getValue());
+        self::assertEquals('replace', $map->getCrmData()->getMode());
     }
     
     private function getConfig()
@@ -36,7 +38,7 @@ class FieldMapGroupTest extends TestCase
         ];
     }
     
-    public function testGetCrmDataArray__remove()
+    public function testGetCrmData__remove()
     {
         $map = new FieldMapGroup($this->getConfig());
         $data = [
@@ -47,7 +49,9 @@ class FieldMapGroupTest extends TestCase
         
         $map->addMailchimpData($data);
         
-        $this->assertEquals(['newsletterCountryD' => 'no'], $map->getCrmDataArray());
+        self::assertEquals('newsletterCountryD', $map->getCrmData()->getKey());
+        self::assertEquals('no', $map->getCrmData()->getValue());
+        self::assertEquals('replace', $map->getCrmData()->getMode());
     }
     
     public function testGetMailchimpDataArray__add()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Bool__Test.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Bool__Test.php
@@ -72,11 +72,14 @@ class FieldMapGroup__Bool__Test extends TestCase
     public function testGetMailchimpDataArray__remove()
     {
         $map = new FieldMapGroup($this->getConfig());
-        
+    
         $map->addCrmData(['newsletterCountryD' => 'no']);
         $this->assertEquals(['55f795def4' => false], $map->getMailchimpDataArray());
-        
+    
         $map->addCrmData(['newsletterCountryD' => '']);
+        $this->assertEquals(['55f795def4' => false], $map->getMailchimpDataArray());
+    
+        $map->addCrmData(['newsletterCountryD' => null]);
         $this->assertEquals(['55f795def4' => false], $map->getMailchimpDataArray());
     }
     

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Bool__Test.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Bool__Test.php
@@ -11,10 +11,10 @@ class FieldMapGroup__Bool__Test extends TestCase
     {
         $map = new FieldMapGroup($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
-        
-        self::assertEquals('newsletterCountryD', $map->getCrmData()->getKey());
-        self::assertEquals('yes', $map->getCrmData()->getValue());
-        self::assertEquals('replace', $map->getCrmData()->getMode());
+    
+        self::assertEquals('newsletterCountryD', $map->getCrmData()[0]->getKey());
+        self::assertEquals('yes', $map->getCrmData()[0]->getValue());
+        self::assertEquals('replace', $map->getCrmData()[0]->getMode());
     }
     
     private function getConfig()
@@ -46,12 +46,12 @@ class FieldMapGroup__Bool__Test extends TestCase
                 '55f795def4' => false
             ]
         ];
-        
+    
         $map->addMailchimpData($data);
-        
-        self::assertEquals('newsletterCountryD', $map->getCrmData()->getKey());
-        self::assertEquals('no', $map->getCrmData()->getValue());
-        self::assertEquals('replace', $map->getCrmData()->getMode());
+    
+        self::assertEquals('newsletterCountryD', $map->getCrmData()[0]->getKey());
+        self::assertEquals('no', $map->getCrmData()[0]->getValue());
+        self::assertEquals('replace', $map->getCrmData()[0]->getMode());
     }
     
     public function testGetMailchimpDataArray__add()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Contains__Test.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Contains__Test.php
@@ -1,0 +1,94 @@
+<?php /** @noinspection PhpUnhandledExceptionInspection */
+
+namespace App\Synchronizer\Mapper\FieldMaps;
+
+
+use Tests\TestCase;
+
+class FieldMapGroup__Contains__Test extends TestCase
+{
+    public function testGetCrmData__add()
+    {
+        $map = new FieldMapGroup($this->getConfig());
+        $map->addMailchimpData($this->getMailchimpData());
+        
+        self::assertEquals('notesCountry', $map->getCrmData()->getKey());
+        self::assertStringContainsString('PolitletterDE', $map->getCrmData()->getValue());
+        self::assertEquals('append', $map->getCrmData()->getMode());
+    }
+    
+    private function getConfig()
+    {
+        return [
+            'crmKey' => 'notesCountry',
+            'mailchimpCategoryId' => 'bba5d2d564',
+            'type' => 'group',
+            'trueContainsString' => 'PolitletterDE',
+            'falseContainsString' => 'PolitletterUnsubscribed',
+            'sync' => 'both'
+        ];
+    }
+    
+    private function getMailchimpData()
+    {
+        return [
+            'interests' => [
+                'bba5d2d564' => true
+            ]
+        ];
+    }
+    
+    public function testGetCrmData__remove()
+    {
+        $map = new FieldMapGroup($this->getConfig());
+        $data = [
+            'interests' => [
+                'bba5d2d564' => false
+            ]
+        ];
+        
+        $map->addMailchimpData($data);
+        
+        self::assertEquals('notesCountry', $map->getCrmData()->getKey());
+        self::assertStringContainsString('PolitletterUnsubscribed', $map->getCrmData()->getValue());
+        self::assertEquals('append', $map->getCrmData()->getMode());
+    }
+    
+    public function testGetMailchimpDataArray__add()
+    {
+        $map = new FieldMapGroup($this->getConfig());
+        $map->addCrmData($this->getCrmData());
+        
+        $this->assertEquals(['bba5d2d564' => true], $map->getMailchimpDataArray());
+    }
+    
+    private function getCrmData()
+    {
+        return [
+            'notesCountry' => "some notes.\nother PolitletterDE. some\nother notes",
+        ];
+    }
+    
+    public function testGetMailchimpDataArray__remove()
+    {
+        $map = new FieldMapGroup($this->getConfig());
+        
+        $map->addCrmData(['notesCountry' => 'PolitletterDE PolitletterUnsubscribed']);
+        $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
+        
+        $map->addCrmData(['notesCountry' => 'PolitletterUnsubscribed PolitletterDE']);
+        $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
+        
+        $map->addCrmData(['notesCountry' => 'PolitletterUnsubscribed']);
+        $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
+        
+        $map->addCrmData(['notesCountry' => '']);
+        $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
+    }
+    
+    public function testGetMailchimpParentKey()
+    {
+        $map = new FieldMapGroup($this->getConfig());
+        $this->assertEquals('interests', $map->getMailchimpParentKey());
+    }
+}

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Contains__Test.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Contains__Test.php
@@ -75,14 +75,17 @@ class FieldMapGroup__Contains__Test extends TestCase
         
         $map->addCrmData(['notesCountry' => 'PolitletterDE PolitletterUnsubscribed']);
         $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
-        
+    
         $map->addCrmData(['notesCountry' => 'PolitletterUnsubscribed PolitletterDE']);
         $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
-        
+    
         $map->addCrmData(['notesCountry' => 'PolitletterUnsubscribed']);
         $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
-        
+    
         $map->addCrmData(['notesCountry' => '']);
+        $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
+    
+        $map->addCrmData(['notesCountry' => null]);
         $this->assertEquals(['bba5d2d564' => false], $map->getMailchimpDataArray());
     }
     

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Contains__Test.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapGroup__Contains__Test.php
@@ -11,10 +11,10 @@ class FieldMapGroup__Contains__Test extends TestCase
     {
         $map = new FieldMapGroup($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
-        
-        self::assertEquals('notesCountry', $map->getCrmData()->getKey());
-        self::assertStringContainsString('PolitletterDE', $map->getCrmData()->getValue());
-        self::assertEquals('append', $map->getCrmData()->getMode());
+    
+        self::assertEquals('notesCountry', $map->getCrmData()[0]->getKey());
+        self::assertStringContainsString('PolitletterDE', $map->getCrmData()[0]->getValue());
+        self::assertEquals('append', $map->getCrmData()[0]->getMode());
     }
     
     private function getConfig()
@@ -46,12 +46,16 @@ class FieldMapGroup__Contains__Test extends TestCase
                 'bba5d2d564' => false
             ]
         ];
-        
+    
         $map->addMailchimpData($data);
-        
-        self::assertEquals('notesCountry', $map->getCrmData()->getKey());
-        self::assertStringContainsString('PolitletterUnsubscribed', $map->getCrmData()->getValue());
-        self::assertEquals('append', $map->getCrmData()->getMode());
+    
+        self::assertEquals('notesCountry', $map->getCrmData()[0]->getKey());
+        self::assertStringContainsString('PolitletterUnsubscribed', $map->getCrmData()[0]->getValue());
+        self::assertEquals('append', $map->getCrmData()[0]->getMode());
+    
+        self::assertEquals('notesCountry', $map->getCrmData()[1]->getKey());
+        self::assertStringContainsString('PolitletterDE', $map->getCrmData()[1]->getValue());
+        self::assertEquals('remove', $map->getCrmData()[1]->getMode());
     }
     
     public function testGetMailchimpDataArray__add()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapMergeTest.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapMergeTest.php
@@ -45,12 +45,14 @@ class FieldMapMergeTest extends TestCase
         $this->assertTrue($map->canSyncToCrm());
     }
     
-    public function testGetCrmDataArray()
+    public function testGetCrmData()
     {
         $map = new FieldMapMerge($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
-        
-        $this->assertEquals(['firstName' => 'Hugo'], $map->getCrmDataArray());
+    
+        self::assertEquals('firstName', $map->getCrmData()->getKey());
+        self::assertEquals('Hugo', $map->getCrmData()->getValue());
+        self::assertEquals('replace', $map->getCrmData()->getMode());
     }
     
     private function getMailchimpData()
@@ -62,14 +64,16 @@ class FieldMapMergeTest extends TestCase
         ];
     }
     
-    public function testGetCrmDataArray__default()
+    public function testGetCrmData__default()
     {
         $map = new FieldMapMerge($this->getConfig());
         $data = $this->getMailchimpData();
         $data['merge_fields']['FNAME'] = '';
         $map->addMailchimpData($data);
         
-        $this->assertEquals(['firstName' => 'asdf'], $map->getCrmDataArray());
+        self::assertEquals('firstName', $map->getCrmData()->getKey());
+        self::assertEquals('asdf', $map->getCrmData()->getValue());
+        self::assertEquals('replace', $map->getCrmData()->getMode());
     }
     
     public function testGetMailchimpDataArray()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapMergeTest.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapMergeTest.php
@@ -50,9 +50,9 @@ class FieldMapMergeTest extends TestCase
         $map = new FieldMapMerge($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
     
-        self::assertEquals('firstName', $map->getCrmData()->getKey());
-        self::assertEquals('Hugo', $map->getCrmData()->getValue());
-        self::assertEquals('replace', $map->getCrmData()->getMode());
+        self::assertEquals('firstName', $map->getCrmData()[0]->getKey());
+        self::assertEquals('Hugo', $map->getCrmData()[0]->getValue());
+        self::assertEquals('replace', $map->getCrmData()[0]->getMode());
     }
     
     private function getMailchimpData()
@@ -70,10 +70,10 @@ class FieldMapMergeTest extends TestCase
         $data = $this->getMailchimpData();
         $data['merge_fields']['FNAME'] = '';
         $map->addMailchimpData($data);
-        
-        self::assertEquals('firstName', $map->getCrmData()->getKey());
-        self::assertEquals('asdf', $map->getCrmData()->getValue());
-        self::assertEquals('replace', $map->getCrmData()->getMode());
+    
+        self::assertEquals('firstName', $map->getCrmData()[0]->getKey());
+        self::assertEquals('asdf', $map->getCrmData()[0]->getValue());
+        self::assertEquals('replace', $map->getCrmData()[0]->getMode());
     }
     
     public function testGetMailchimpDataArray()

--- a/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapTagTest.php
+++ b/tests/Unit/Synchronizer/Mapper/FieldMaps/FieldMapTagTest.php
@@ -29,7 +29,7 @@ class FieldMapTagTest extends TestCase
         $map = new FieldMapTag($this->getConfig());
         $map->addMailchimpData($this->getMailchimpData());
         
-        $this->assertEmpty($map->getCrmDataArray());
+        $this->assertEmpty($map->getCrmData());
     }
     
     private function getMailchimpData()

--- a/tests/Unit/Synchronizer/Mapper/MapperTest.php
+++ b/tests/Unit/Synchronizer/Mapper/MapperTest.php
@@ -14,14 +14,12 @@ class MapperTest extends TestCase
         $crmData = $mapper->mailchimpToCrm($this->getMailchimpData());
     
         self::assertArrayHasKey('email1', $crmData);
-        self::assertEquals('email1', $crmData['email1']->getKey());
-        self::assertEquals('info@example.org', $crmData['email1']->getValue());
-        self::assertEquals('replace', $crmData['email1']->getMode());
+        self::assertEquals('info@example.org', $crmData['email1'][0]['value']);
+        self::assertEquals('replace', $crmData['email1'][0]['mode']);
     
         self::assertArrayHasKey('newsletterCountryD', $crmData);
-        self::assertEquals('newsletterCountryD', $crmData['newsletterCountryD']->getKey());
-        self::assertEquals('yes', $crmData['newsletterCountryD']->getValue());
-        self::assertEquals('replace', $crmData['newsletterCountryD']->getMode());
+        self::assertEquals('yes', $crmData['newsletterCountryD'][0]['value']);
+        self::assertEquals('replace', $crmData['newsletterCountryD'][0]['mode']);
     }
     
     private function getFieldMaps()

--- a/tests/Unit/Synchronizer/Mapper/MapperTest.php
+++ b/tests/Unit/Synchronizer/Mapper/MapperTest.php
@@ -12,12 +12,16 @@ class MapperTest extends TestCase
     {
         $mapper = new Mapper($this->getFieldMaps());
         $crmData = $mapper->mailchimpToCrm($this->getMailchimpData());
-        
-        $expectedData = [
-            'email1' => 'info@example.org',
-            'newsletterCountryD' => 'yes',
-        ];
-        $this->assertEquals($expectedData, $crmData);
+    
+        self::assertArrayHasKey('email1', $crmData);
+        self::assertEquals('email1', $crmData['email1']->getKey());
+        self::assertEquals('info@example.org', $crmData['email1']->getValue());
+        self::assertEquals('replace', $crmData['email1']->getMode());
+    
+        self::assertArrayHasKey('newsletterCountryD', $crmData);
+        self::assertEquals('newsletterCountryD', $crmData['newsletterCountryD']->getKey());
+        self::assertEquals('yes', $crmData['newsletterCountryD']->getValue());
+        self::assertEquals('replace', $crmData['newsletterCountryD']->getMode());
     }
     
     private function getFieldMaps()

--- a/tests/test.io.yml
+++ b/tests/test.io.yml
@@ -58,6 +58,12 @@ fields:
     trueCondition: yes
     falseCondition: no
     sync: both
+  - crmKey: notesCountry
+    mailchimpCategoryId: bba5d2d564
+    type: group
+    trueContainsString: PolitletterDE
+    falseContainsString: PolitletterUnsubscribed
+    sync: both
   - crmKey: memberStatusCountry
     mailchimpTagName: member
     type: tag


### PR DESCRIPTION
* Adds the possibility to map tags (substring of a text field) in the crm to groups in mailchimp.
  * There is one tag for subscription and another tag for explicit unsubscription 
  * If someone subscribes to a group, the subscription tag is added and the unsubsciption tag is removes (if present)
  * If someone unsubscribes from a group, it happens vice-versa
  * The unsubscribe tag has precedence over the subscribe tag (but usually only one should be present)
  * Adding an unsubscribe tag provides the info, that the person actively unsubscribed (opposed to a missing subscribe tag, that tells us nothing about the persons intent)
* updated PHP dependencies 