### PR TITLE
Allow admins to disable Notifications for direct Subscriptions in Mailchimp

### DIFF
--- a/app/Synchronizer/Config.php
+++ b/app/Synchronizer/Config.php
@@ -162,6 +162,20 @@ class Config
         
         return false;
     }
+
+    /**
+     * Return bool that indicates if subscriptions through mailchimp should be ignored
+     *
+     * @return bool
+     */
+    public function getIgnoreSubscribeThroughMailchimp(): bool
+    {
+        if (array_key_exists('ignoreSubscribeThroughMailchimp', $this->mailchimp)) {
+            return filter_var($this->mailchimp['ignoreSubscribeThroughMailchimp'], FILTER_VALIDATE_BOOLEAN);
+        }
+
+        return false;
+    }
     
     /**
      * Return the default list id in Mailchimp

--- a/app/Synchronizer/MailchimpToCrmSynchronizer.php
+++ b/app/Synchronizer/MailchimpToCrmSynchronizer.php
@@ -93,19 +93,22 @@ class MailchimpToCrmSynchronizer
         
         switch ($callType) {
             case self::MC_SUBSCRIBE:
-                $mcData = $this->mcClient->getSubscriber($email);
-                $mergeFields = $this->extractMergeFields($mcData);
-    
-                // if there is no crm id
-                if (empty($mergeFields[$this->config->getMailchimpKeyOfCrmId()])) {
-                    // send mail to dataOwner, that he should
-                    // add the subscriber to webling not mailchimp
-                    $this->sendMailSubscribeOnlyInWebling($this->config->getDataOwner(), $mcData);
-                    $this->logWebhook('debug', $callType, $mailchimpId, "Notified data owner.");
+                // if configured, don't send notifications, if not, keep backwards compatibility
+                if(!$this->config->getIgnoreSubscribeThroughMailchimp()) {
+                    $mcData = $this->mcClient->getSubscriber($email);
+                    $mergeFields = $this->extractMergeFields($mcData);
+
+                    // if there is no crm id
+                    if (empty($mergeFields[$this->config->getMailchimpKeyOfCrmId()])) {
+                        // send mail to dataOwner, that he should
+                        // add the subscriber to webling not mailchimp
+                        $this->sendMailSubscribeOnlyInWebling($this->config->getDataOwner(), $mcData);
+                        $this->logWebhook('debug', $callType, $mailchimpId, "Notified data owner.");
+                    }
                 }
-    
+
                 return;
-    
+
             case self::MC_UNSUBSCRIBE:
                 $mergeFields = $this->extractMergeFields($mcData['data']);
                 $crmId = $mergeFields[$this->config->getMailchimpKeyOfCrmId()];

--- a/config/example.com.yml
+++ b/config/example.com.yml
@@ -14,6 +14,7 @@ mailchimp:
   listId: 6f33e28fa3
   interesstCategoriesId: de75614d35
   syncAll: false
+  ignoreSubscribeThroughMailchimp: true
 
 webling:
   prioritizedGroups:

--- a/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
+++ b/tests/Unit/Synchronizer/MailchimpToCrmSynchronizerTest.php
@@ -122,17 +122,21 @@ class MailchimpToCrmSynchronizerTest extends TestCase
         ];
         
         $this->sync->syncSingle($webhookData);
-        
-        Mail::assertSent(WrongSubscription::class, function ($mail) use ($subscriber) {
-            $this->assertEquals($subscriber['merge_fields']['FNAME'], $mail->mail->contactFirstName);
-            $this->assertEquals($subscriber['merge_fields']['LNAME'], $mail->mail->contactLastName);
-            $this->assertEquals($subscriber['email_address'], $mail->mail->contactEmail);
-            $this->assertEquals(env('ADMIN_EMAIL'), $mail->mail->adminEmail);
-            $this->assertEquals($this->config->getDataOwner()['name'], $mail->mail->dataOwnerName);
-            $this->assertEquals(self::CONFIG_FILE_NAME, $mail->mail->configName);
+
+        if ($this->config->getIgnoreSubscribeThroughMailchimp()) {
+            Mail::assertNotSent(WrongSubscription::class);
+        } else {
+            Mail::assertSent(WrongSubscription::class, function ($mail) use ($subscriber) {
+                $this->assertEquals($subscriber['merge_fields']['FNAME'], $mail->mail->contactFirstName);
+                $this->assertEquals($subscriber['merge_fields']['LNAME'], $mail->mail->contactLastName);
+                $this->assertEquals($subscriber['email_address'], $mail->mail->contactEmail);
+                $this->assertEquals(env('ADMIN_EMAIL'), $mail->mail->adminEmail);
+                $this->assertEquals($this->config->getDataOwner()['name'], $mail->mail->dataOwnerName);
+                $this->assertEquals(self::CONFIG_FILE_NAME, $mail->mail->configName);
     
-            return true;
-        });
+                return true;
+            });
+        }
     
         // cleanup
         $this->mcClientTesting->deleteSubscriber($email);
@@ -182,17 +186,21 @@ class MailchimpToCrmSynchronizerTest extends TestCase
         
         $this->sync->syncSingle($webhookData);
         
-        Mail::assertSent(WrongSubscription::class, function ($mail) use ($subscriber) {
-            $this->assertEquals($subscriber['merge_fields']['FNAME'], $mail->mail->contactFirstName);
-            $this->assertEquals($subscriber['merge_fields']['LNAME'], $mail->mail->contactLastName);
-            $this->assertEquals($subscriber['email_address'], $mail->mail->contactEmail);
-            $this->assertEquals(env('ADMIN_EMAIL'), $mail->mail->adminEmail);
-            $this->assertEquals($this->config->getDataOwner()['name'], $mail->mail->dataOwnerName);
-            $this->assertEquals(self::CONFIG_FILE_NAME, $mail->mail->configName);
-            
-            return true;
-        });
-        
+        if ($this->config->getIgnoreSubscribeThroughMailchimp()) {
+            Mail::assertNotSent(WrongSubscription::class);
+        } else {
+            Mail::assertSent(WrongSubscription::class, function ($mail) use ($subscriber) {
+                $this->assertEquals($subscriber['merge_fields']['FNAME'], $mail->mail->contactFirstName);
+                $this->assertEquals($subscriber['merge_fields']['LNAME'], $mail->mail->contactLastName);
+                $this->assertEquals($subscriber['email_address'], $mail->mail->contactEmail);
+                $this->assertEquals(env('ADMIN_EMAIL'), $mail->mail->adminEmail);
+                $this->assertEquals($this->config->getDataOwner()['name'], $mail->mail->dataOwnerName);
+                $this->assertEquals(self::CONFIG_FILE_NAME, $mail->mail->configName);
+
+                return true;
+            });
+        }
+
         // cleanup
         $this->mcClientTesting->deleteSubscriber($email);
     }

--- a/tests/test.io.yml
+++ b/tests/test.io.yml
@@ -14,6 +14,7 @@ mailchimp:
   listId: 6f33e28fa3
   interesstCategoriesId: de75614d35
   syncAll: false
+  ignoreSubscribeThroughMailchimp: true
 
 webling:
   prioritizedGroups:


### PR DESCRIPTION
Added a config var to disable notifications, fixed tests